### PR TITLE
Tweaks to index methods for latest Neo4j release

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -88,10 +88,10 @@ To Use:
   @neo.remove_relationship_properties(rel1, "since")         # Remove one property of a relationship
   @neo.remove_relationship_properties(rel1, ["since","met"]) # Remove multiple properties of a relationship
 
-  @neo.list_indexes                                          # doesn't really seam to do what the api says it does
-  @neo.add_to_index(key, value, node1)                       # adds a node to an index with the given key/value pair
-  @neo.remove_from_index(key, value, node1)                  # removes a node to an index with the given key/value pair
-  @neo.get_index(key, value)                                 # gets an index with the given key/value pair
+  @neo.list_indexes                                          # gives names and query templates for all defined indices
+  @neo.add_to_index(index, key, value, node1)                # adds a node to the specified index with the given key/value pair
+  @neo.remove_from_index(index, key, value, node1)           # removes a node from the specified index with the given key/value pair
+  @neo.get_index(index, key, value)                          # queries the specified index with the given key/value pair
 
   @neo.get_path(node1, node2, relationships, depth=4, algorithm="shortestPath") # finds the shortest path between two nodes 
   @neo.get_paths(node1, node2, relationships, depth=3, algorithm="allPaths")    # finds all paths between two nodes

--- a/lib/neography/rest.rb
+++ b/lib/neography/rest.rb
@@ -210,20 +210,20 @@ module Neography
       end
 
       def list_indexes
-        get("/index")
+        get("/index/node")
       end
 
-      def add_to_index(key, value, id)
+      def add_to_index(index, key, value, id)
         options = { :body => (self.configuration + "/node/#{get_id(id)}").to_json, :headers => {'Content-Type' => 'application/json'} } 
-        post("/index/node/#{key}/#{value}", options)
+        post("/index/node/#{index}/#{key}/#{value}", options)
       end
 
-      def remove_from_index(key, value, id)
-        delete("/index/node/#{key}/#{value}/#{get_id(id)}")
+      def remove_from_index(index, key, value, id)
+        delete("/index/node/#{index}/#{key}/#{value}/#{get_id(id)}")
       end
 
-      def get_index(key, value)
-        index = get("/index/node/#{key}/#{value}") || Array.new
+      def get_index(index, key, value)
+        index = get("/index/node/#{index}/#{key}/#{value}") || Array.new
         return nil if index.empty?
         index
       end


### PR DESCRIPTION
Hi.  The Neo4j folks have changed their indexing API in the latest release (M06):

http://components.neo4j.org/neo4j-server/0.5-SNAPSHOT/rest.html#Listing_node_indexes

Specifically, we have to pass in an additional parameter naming the index.  Instead of /index/node/some_key/some_value, it's now /index/node/some_index/some_key/some_value.

The attached patch adds an "index" parameter to "add_to_index", "remove_from_index", and "get_index".  It also tweaks the URL inside the "list_indexes" method (without changing the signature).  The README is updated as well.

Thanks for making Neography, by the way.  It makes some neat applications possible.
