### PR TITLE
server is not passed in traversal-noded

### DIFF
--- a/lib/neography/relationship_traverser.rb
+++ b/lib/neography/relationship_traverser.rb
@@ -21,8 +21,8 @@ module Neography
     def each
       iterator.each do |i| 
         rel = Neography::Relationship.new(i, @node.neo_server)
-        rel.start_node = Neography::Node.load(rel.start_node)
-        rel.end_node = Neography::Node.load(rel.end_node)
+        rel.start_node = Neography::Node.load(rel.start_node, @node.neo_server)
+        rel.end_node = Neography::Node.load(rel.end_node, @node.neo_server)
 
         yield rel if match_to_other?(rel)
       end

--- a/lib/neography/version.rb
+++ b/lib/neography/version.rb
@@ -1,3 +1,3 @@
 module Neography
-  VERSION = "0.0.12"
+  VERSION = "0.0.13"
 end


### PR DESCRIPTION
hey max,

michael hunger and i found this bug when traversing nodes and not using the default-server.
the created start/end node will not get the right server. could you please pull it in?

cheers, thomas
