### PR TITLE
Added config settings for plugin paths

### DIFF
--- a/lib/neography/config.rb
+++ b/lib/neography/config.rb
@@ -1,17 +1,19 @@
 module Neography
   class Config 
-    class << self; attr_accessor :protocol, :server, :port, :directory, :log_file, :log_enabled, :logger, :max_threads, :authentication, :username, :password end
+    class << self; attr_accessor :protocol, :server, :port, :directory, :cypher_path, :gremlin_path, :log_file, :log_enabled, :logger, :max_threads, :authentication, :username, :password end
 
-    @protocol = 'http://'
-    @server = 'localhost'
-    @port = 7474 
-    @directory = ''
-    @log_file = 'neography.log'
-    @log_enabled = false
-    @logger = Logger.new(@log_file) if @log_enabled
-    @max_threads = 20
+    @protocol       = 'http://'
+    @server         = 'localhost'
+    @port           = 7474 
+    @directory      = ''
+    @cypher_path    = '/cypher'
+    @gremlin_path   = '/ext/GremlinPlugin/graphdb/execute_script'
+    @log_file       = 'neography.log'
+    @log_enabled    = false
+    @logger         = Logger.new(@log_file) if @log_enabled
+    @max_threads    = 20
     @authentication = {}
-    @username = nil
-    @password = nil
+    @username       = nil
+    @password       = nil
   end
 end

--- a/lib/neography/rest.rb
+++ b/lib/neography/rest.rb
@@ -2,13 +2,15 @@ module Neography
   class Rest
     include HTTParty
 
-    attr_accessor :protocol, :server, :port, :directory, :log_file, :log_enabled, :logger, :max_threads, :authentication, :username, :password
+    attr_accessor :protocol, :server, :port, :directory, :cypher_path, :gremlin_path, :log_file, :log_enabled, :logger, :max_threads, :authentication, :username, :password
 
       def initialize(options=ENV['NEO4J_URL'] || {})
         init = {:protocol       => Neography::Config.protocol, 
                 :server         => Neography::Config.server, 
                 :port           => Neography::Config.port, 
-                :directory      => Neography::Config.directory, 
+                :directory      => Neography::Config.directory,
+                :cypher_path    => Neography::Config.cypher_path,
+                :gremlin_path   => Neography::Config.gremlin_path, 
                 :log_file       => Neography::Config.log_file, 
                 :log_enabled    => Neography::Config.log_enabled, 
                 :max_threads    => Neography::Config.max_threads,
@@ -34,6 +36,8 @@ module Neography
         @server         = init[:server]
         @port           = init[:port]
         @directory      = init[:directory]
+        @cypher_path    = init[:cypher_path]
+        @gremlin_path   = init[:gremlin_path]
         @log_file       = init[:log_file]
         @log_enabled    = init[:log_enabled]
         @logger         = Logger.new(@log_file) if @log_enabled
@@ -356,12 +360,12 @@ module Neography
 
       def execute_query(query, params = {})
           options = { :body => {:query => query, :params => params}.to_json, :headers => {'Content-Type' => 'application/json'} }
-          result = post("/cypher", options)
+          result = post(@cypher_path, options)
       end
       
       def execute_script(script, params = {})
         options = { :body => {:script => script, :params => params}.to_json , :headers => {'Content-Type' => 'application/json'} }
-        result = post("/ext/GremlinPlugin/graphdb/execute_script", options)
+        result = post(@gremlin_path, options)
         result == "null" ? nil : result
       end
 


### PR DESCRIPTION
I Installed Neo4j on my mac using Homebrew, which means that my Cypher plugin is in a different location from the one expected by Neography. To get round this I added two extra attributes to the Neography::Config class - cypher_path and gremlin_path, which I set the values you were using in Neography::Rest. I updated Neography::Rest to use these config values.

I haven't written any tests because I'm not sure what tests I could write - any suggestions are welcome. My first thought was if the rest_plugin_specs still pass then that should be OK, but if you want me to add something extra let me know.

Cheers,

Nick
