### PR TITLE
fix for issue when setting nonexistent property for the first time using dot notation

### DIFF
--- a/lib/neography/property.rb
+++ b/lib/neography/property.rb
@@ -41,9 +41,13 @@ module Neography
   end
 
 
-  def self.method_missing(method_sym, *arguments, &block)
-    if (method_sym.to_s =~ /$=/) != nil
+  def method_missing(method_sym, *arguments, &block)
+    if (method_sym.to_s =~ /=$/) != nil
       new_ostruct_member(method_sym.to_s.chomp("="))
+
+      # We just defined the getter/setter above, but we haven't actually
+      # applied them yet.
+      self.send(method_sym, *arguments)
     else
       super
     end

--- a/spec/integration/node_spec.rb
+++ b/spec/integration/node_spec.rb
@@ -136,7 +136,7 @@ describe Neography::Node do
       existing_node.eyes.should == "brown"
     end
 
-    it "can change a node's properties that does not already exist" do
+    it "can change a node's properties that does not already exist using []=" do
       new_node = Neography::Node.create("weight" => 150, "eyes" => "green")
 
       new_node.weight = 200
@@ -146,6 +146,15 @@ describe Neography::Node do
       existing_node = Neography::Node.load(new_node)
       existing_node.weight.should == 200
       existing_node.eyes.should == "brown"
+      existing_node.hair.should == "black"
+    end
+
+    it "can change a node's properties that does not already exist" do
+      new_node = Neography::Node.create
+
+      new_node.hair = "black"
+
+      existing_node = Neography::Node.load(new_node)
       existing_node.hair.should == "black"
     end
 


### PR DESCRIPTION
Right now, if you use dot notation to set a property on a node for the first time, like this:

```
  new_node = Neography::Node.create
  new_node.hair = "black"
```

It won't work. This is due to a bug in the implementation of method_missing in the Property module. This commit contains a fix along with an accompanying spec to illustrate the original problem.
