### PR TITLE
Rest#clean_database uses wrong path in uri

### DIFF
--- a/lib/neography/rest.rb
+++ b/lib/neography/rest.rb
@@ -58,7 +58,11 @@ module Neography
       end
 
       def configuration
-        @protocol + @server + ':' + @port.to_s + @directory + "/db/data"
+        configuration_root + "/db/data"
+      end
+
+      def configuration_root
+      @protocol + @server + ':' + @port.to_s + @directory
       end
 
       def get_root
@@ -386,12 +390,12 @@ module Neography
          options = { :body => batch.to_json, :headers => {'Content-Type' => 'application/json'} } 
          post("/batch", options)
       end
-      
+
       # For testing (use a separate neo4j instance)
       # call this before each test or spec
       def clean_database(sanity_check = "not_really")
         if sanity_check == "yes_i_really_want_to_clean_the_database"
-          delete("/cleandb/secret-key")
+          evaluate_response(HTTParty.delete(configuration_root + URI.encode("/cleandb/secret-key"), {}.merge!(@authentication).merge!(@parser)))
           true
         else
           false

--- a/spec/integration/rest_plugin_spec.rb
+++ b/spec/integration/rest_plugin_spec.rb
@@ -64,4 +64,13 @@ describe Neography::Rest do
 
   end
 
+  describe "clean_database" do
+    it "can delete all data" do
+      new_node = @neo.create_node
+      @neo.clean_database("yes_i_really_want_to_clean_the_database")
+      existing_node = @neo.get_node(new_node)
+      existing_node.should be_nil
+    end
+  end
+
 end


### PR DESCRIPTION
Hi

Rest#clean_database didn't work for me using neo4j-community-1.6.
I had to correct the path from /db/data/cleandb/secret-key to /cleandb/secret-key

If you think this solves a general issue, please merge my modification.

Cheers
Jorg
