### PR TITLE
Added 2 more batch operations

### DIFF
--- a/lib/neography/rest.rb
+++ b/lib/neography/rest.rb
@@ -474,11 +474,7 @@ module Neography
               {:method => "POST", :to => @cypher_path, :body => {:query => args[1]}}
             end
           when :remove_node_from_index
-		  	case args.size
-				when 5 then {:method => "DELETE", :to => "/index/node/#{args[1]}/#{args[2]}/#{args[3]}/#{get_id(args[4])}" }
-				when 4 then {:method => "DELETE", :to => "/index/node/#{args[1]}/#{args[2]}/#{get_id(args[3])}" }
-				when 3 then {:method => "DELETE", :to => "/index/node/#{args[1]}/#{get_id(args[2])}" }
-			end
+			 {:method => "DELETE", :to => "/index/node/#{args[1]}/#{args[2]}/#{args[3]}/#{get_id(args[4])}" }
 		  when :delete_node
 		   	{:method => "DELETE", :to => "/node/#{get_id(args[1])}"}
 		  else

--- a/spec/integration/rest_batch_spec.rb
+++ b/spec/integration/rest_batch_spec.rb
@@ -266,6 +266,32 @@ describe Neography::Rest do
       batch_result.first["body"]["data"][0][0]["self"].split('/').last.should == id
     end  
   
+	it "can delete a node in batch" do
+		
+		node1 = @neo.create_node
+		node2 = @neo.create_node
+		id1 = node1['self'].split('/').last
+		id2 = node2['self'].split('/').last
+		batch_result = @neo.batch [:delete_node, id1 ], [:delete_node, id2]
+		@neo.get_node(node1).should be_nil
+		@neo.get_node(node2).should be_nil
+
+	end
+
+	it "can remove a node from an index in batch " do
+		index = generate_text(6)
+		key = generate_text(6)
+		value1 = generate_text
+		value2 = generate_text 
+		
+		node1 = @neo.create_unique_node( index , key  , value1  , { "name" => "Max" } )
+		node2 = @neo.create_unique_node( index , key , value2 , { "name" => "Neo" }) 
+		
+		batch_result = @neo.batch [:remove_node_from_index, index, key, value1, node1 ], [:remove_node_from_index, index, key, value2, node2 ]
+		
+		@neo.get_node_index(index, key, value1).should be_nil
+		@neo.get_node_index(index, key, value2).should be_nil
+	end
 
   end
 


### PR DESCRIPTION
Hey Max, great job with neography.

In my use of neography, I found that I needed to support batch for a few operations not currently implemented in batch, so I took the liberty and

*\* Implemented `delete_node` and `remove_node_from_index` operations. **

This pull request adds the operations to the get_batch method in the 'lib/neography/rest.rb' file.  I also added two spec fixtures to ensure that they work.

Let me know if you have see and issues that need fixing before accepting the request.

Thanks
