### PR TITLE
Fix bug with finding nodes in index with spaces in value. 

### DIFF
--- a/lib/neography/rest.rb
+++ b/lib/neography/rest.rb
@@ -314,7 +314,7 @@ module Neography
 
       def find_node_index(*args)
         case args.size
-          when 3 then index = get("/index/node/#{args[0]}/#{args[1]}/#{args[2]}") || Array.new
+          when 3 then index = get("/index/node/#{args[0]}/#{args[1]}?query=\"#{args[2]}\"") || Array.new
           when 2 then index = get("/index/node/#{args[0]}?query=#{args[1]}") || Array.new
         end
         return nil if index.empty?

--- a/spec/integration/rest_index_spec.rb
+++ b/spec/integration/rest_index_spec.rb
@@ -235,6 +235,17 @@ describe Neography::Rest do
       @neo.remove_node_from_index("test_node_index", key, value, new_node)
     end
 
+    it "can find a node index with slashes in the value" do
+      new_node = @neo.create_node
+      key = generate_text(6)
+      value = generate_text + '/' + generate_text
+      @neo.add_node_to_index("test_node_index", key, value, new_node)
+      new_index = @neo.find_node_index("test_node_index", key, value)
+      new_index.should_not be_nil
+      new_index.first["self"].should == new_node["self"]
+      @neo.remove_node_from_index("test_node_index", key, value, new_node)
+    end
+
     it "can get a relationship index" do
       new_node1 = @neo.create_node
       new_node2 = @neo.create_node


### PR DESCRIPTION
Setup:

``` ruby
new_node = @neo.create_node
key = "someKey"
value = "some value" # this has a space
@neo.add_node_to_index("indexName", key, value, new_node)
```

Before fix:

``` ruby
found_node = @neo.find_node_index("indexName", key, value)
# => nil
```

After fix:

``` ruby
found_node = @neo.find_node_index("indexName", key, value)
# => [{ .. a whole lot of JSON .. }]
```
