### PR TITLE
Remove remaining logic to separate Rest classes.

### DIFF
--- a/lib/neography/rest.rb
+++ b/lib/neography/rest.rb
@@ -167,12 +167,8 @@ module Neography
       @node_indexes.create_unique(index, key, value, props)
     end
 
-    def remove_node_from_index(*args)
-      case args.size
-      when 4 then @node_indexes.remove_by_value(args[0], args[3], args[1], args[2])
-      when 3 then @node_indexes.remove_by_key(args[0], args[2], args[1])
-      when 2 then @node_indexes.remove(args[0], args[1])
-      end
+    def remove_node_from_index(index, id_or_key, id_or_value = nil, id = nil)
+      @node_indexes.remove(index, id_or_key, id_or_value, id)
     end
     alias_method :remove_from_index, :remove_node_from_index
 
@@ -181,13 +177,8 @@ module Neography
     end
     alias_method :get_index, :get_node_index
 
-    def find_node_index(*args)
-      case args.size
-      when 3 then index = @node_indexes.find_by_key_value(args[0], args[1], args[2])
-      when 2 then index = @node_indexes.find_by_query(args[0], args[1])
-      end
-      return nil if index.empty?
-      index
+    def find_node_index(index, key_or_query, value = nil)
+      @node_indexes.find(index, key_or_query, value)
     end
 
     # auto node indexes
@@ -196,13 +187,8 @@ module Neography
       @node_auto_indexes.get(key, value)
     end
 
-    def find_node_auto_index(*args)
-      case args.size
-      when 2 then index = @node_auto_indexes.find(args[0], args[1])
-      when 1 then index = @node_auto_indexes.query(args[0])
-      end
-      return nil if index.empty?
-      index
+    def find_node_auto_index(key_or_query, value = nil)
+      @node_auto_indexes.find_or_query(key_or_query, value)
     end
 
     def get_node_auto_index_status
@@ -247,25 +233,16 @@ module Neography
       @relationship_indexes.add(index, key, value, id)
     end
 
-    def remove_relationship_from_index(*args)
-      case args.size
-      when 4 then @relationship_indexes.remove_by_value(args[0], get_id(args[3]), args[1], args[2])
-      when 3 then @relationship_indexes.remove_by_key(args[0], get_id(args[2]), args[1])
-      when 2 then @relationship_indexes.remove(args[0], get_id(args[1]))
-      end
+    def remove_relationship_from_index(index, id_or_key, id_or_value = nil, id = nil)
+      @relationship_indexes.remove(index, id_or_key, id_or_value, id)
     end
 
     def get_relationship_index(index, key, value)
       @relationship_indexes.get(index, key, value)
     end
 
-    def find_relationship_index(*args)
-      case args.size
-      when 3 then index = @relationship_indexes.find_by_key_value(args[0], args[1], args[2])
-      when 2 then index = @relationship_indexes.find_by_query(args[0], args[1])
-      end
-      return nil if index.empty?
-      index
+    def find_relationship_index(index, key_or_query, value = nil)
+      @relationship_indexes.find(index, key_or_query, value)
     end
 
     # relationship auto indexes
@@ -274,13 +251,8 @@ module Neography
       @relationship_auto_indexes.get(key, value)
     end
 
-    def find_relationship_auto_index(*args)
-      case args.size
-      when 2 then index = @relationship_auto_indexes.find(args[0], args[1])
-      when 1 then index = @relationship_auto_indexes.query(args[0])
-      end
-      return nil if index.empty?
-      index
+    def find_relationship_auto_index(key_or_query, value = nil)
+      @relationship_auto_indexes.find_or_query(key_or_query, value)
     end
 
     def get_relationship_auto_index_status

--- a/lib/neography/rest/auto_indexes.rb
+++ b/lib/neography/rest/auto_indexes.rb
@@ -13,6 +13,16 @@ module Neography
         index
       end
 
+      def find_or_query(key_or_query, value = nil)
+        if value
+          index = find(key_or_query, value)
+        else
+          index = query(key_or_query)
+        end
+        return nil if index.empty?
+        index
+      end
+
       def find(key, value)
         @connection.get(key_value_path(:key => key, :value => value)) || []
       end

--- a/lib/neography/rest/indexes.rb
+++ b/lib/neography/rest/indexes.rb
@@ -51,6 +51,16 @@ module Neography
         index
       end
 
+      def find(index, key_or_query, value = nil)
+        if value
+          index = find_by_key_value(index, key_or_query, value)
+        else
+          index = find_by_query(index, key_or_query)
+        end
+        return nil if index.empty?
+        index
+      end
+
       def find_by_key_value(index, key, value)
         @connection.get(key_value_path(:index => index, :key => key, :value => value)) || []
       end
@@ -59,7 +69,18 @@ module Neography
         @connection.get(query_path(:index => index, :query => query)) || []
       end
 
-      def remove(index, id)
+      # Mimick original neography API in Rest class.
+      def remove(index, id_or_key, id_or_value = nil, id = nil)
+        if id
+          remove_by_value(index, id, id_or_key, id_or_value)
+        elsif id_or_value
+          remove_by_key(index, id_or_value, id_or_key)
+        else
+          remove_by_id(index, id_or_key)
+        end
+      end
+
+      def remove_by_id(index, id)
         @connection.delete(id_path(:index => index, :id => get_id(id)))
       end
 

--- a/spec/unit/rest/node_auto_indexes_spec.rb
+++ b/spec/unit/rest/node_auto_indexes_spec.rb
@@ -17,6 +17,16 @@ module Neography
         subject.get("some_key", "some_value").should be_nil
       end
 
+      it "finds by key and value if value passed to #find_or_query" do
+        connection.should_receive(:get).with("/index/auto/node/some_key/some_value")
+        subject.find_or_query("some_key", "some_value")
+      end
+
+      it "finds by query if no value passed to #find_or_query" do
+        connection.should_receive(:get).with("/index/auto/node/?query=some_query")
+        subject.find_or_query("some_query")
+      end
+
       it "finds by key and value" do
         connection.should_receive(:get).with("/index/auto/node/some_key/some_value")
         subject.find("some_key", "some_value")

--- a/spec/unit/rest/node_indexes_spec.rb
+++ b/spec/unit/rest/node_indexes_spec.rb
@@ -71,6 +71,16 @@ module Neography
         subject.get("some_index", "some_key", "some_value").should be_nil
       end
 
+      it "finds by key and value if both passed to #find" do
+        connection.should_receive(:get).with("/index/node/some_index/some_key/some_value")
+        subject.find("some_index", "some_key", "some_value")
+      end
+
+      it "finds by query if no value passed to #find" do
+        connection.should_receive(:get).with("/index/node/some_index?query=some_query")
+        subject.find("some_index", "some_query")
+      end
+
       it "finds by key and value" do
         connection.should_receive(:get).with("/index/node/some_index/some_key/some_value")
         subject.find_by_key_value("some_index", "some_key", "some_value")
@@ -81,9 +91,24 @@ module Neography
         subject.find_by_query("some_index", "some_query")
       end
 
-      it "removes a node from an index" do
+      it "removes a node from an index by id for #remove with two arguments" do
         connection.should_receive(:delete).with("/index/node/some_index/42")
         subject.remove("some_index", "42")
+      end
+
+      it "removes a node from an index by key for #remove with three arguments" do
+        connection.should_receive(:delete).with("/index/node/some_index/some_key/42")
+        subject.remove("some_index", "some_key", "42")
+      end
+
+      it "removes a node from an index by key and value for #remove with four arguments" do
+        connection.should_receive(:delete).with("/index/node/some_index/some_key/some_value/42")
+        subject.remove("some_index", "some_key", "some_value", "42")
+      end
+
+      it "removes a node from an index" do
+        connection.should_receive(:delete).with("/index/node/some_index/42")
+        subject.remove_by_id("some_index", "42")
       end
 
       it "removes a node from an index by key" do

--- a/spec/unit/rest/relationship_auto_indexes_spec.rb
+++ b/spec/unit/rest/relationship_auto_indexes_spec.rb
@@ -17,6 +17,16 @@ module Neography
         subject.get("some_key", "some_value").should be_nil
       end
 
+      it "finds by key and value if value passed to #find_or_query" do
+        connection.should_receive(:get).with("/index/auto/relationship/some_key/some_value")
+        subject.find_or_query("some_key", "some_value")
+      end
+
+      it "finds by query if no value passed to #find_or_query" do
+        connection.should_receive(:get).with("/index/auto/relationship/?query=some_query")
+        subject.find_or_query("some_query")
+      end
+
       it "finds by key and value" do
         connection.should_receive(:get).with("/index/auto/relationship/some_key/some_value")
         subject.find("some_key", "some_value")

--- a/spec/unit/rest/relationship_indexes_spec.rb
+++ b/spec/unit/rest/relationship_indexes_spec.rb
@@ -73,6 +73,16 @@ module Neography
         subject.get("some_index", "some_key", "some_value").should be_nil
       end
 
+      it "finds by key and value if both passed to #find" do
+        connection.should_receive(:get).with("/index/relationship/some_index/some_key/some_value")
+        subject.find("some_index", "some_key", "some_value")
+      end
+
+      it "finds by query if no value passed to #find" do
+        connection.should_receive(:get).with("/index/relationship/some_index?query=some_query")
+        subject.find("some_index", "some_query")
+      end
+
       it "finds by key query" do
         connection.should_receive(:get).with("/index/relationship/some_index/some_key/some_value")
         subject.find_by_key_value("some_index", "some_key", "some_value")
@@ -83,9 +93,24 @@ module Neography
         subject.find_by_query("some_index", "some_query")
       end
 
-      it "removes a relationship from an index" do
+      it "removes a relationship from an index for #remove with two arguments" do
         connection.should_receive(:delete).with("/index/relationship/some_index/42")
         subject.remove("some_index", "42")
+      end
+
+      it "removes a relationship from an index by key for #remove with three arguments" do
+        connection.should_receive(:delete).with("/index/relationship/some_index/some_key/42")
+        subject.remove("some_index", "some_key", "42")
+      end
+
+      it "removes a relationship from an index by key and value for #remove with four arguments" do
+        connection.should_receive(:delete).with("/index/relationship/some_index/some_key/some_value/42")
+        subject.remove("some_index", "some_key", "some_value", "42")
+      end
+
+      it "removes a relationship from an index" do
+        connection.should_receive(:delete).with("/index/relationship/some_index/42")
+        subject.remove_by_id("some_index", "42")
       end
 
       it "removes a relationship from an index by key" do


### PR DESCRIPTION
This removes most of the logic that remained in the `Rest` class into the separate classes I've created earlier.

This change actually prepares my next change, which simply [delegates all code](https://github.com/rdvdijk/neography/blob/forwarded_rest/lib/neography/rest.rb) to the classes.

Can you take a look at the link above and see if you like it? If so, I'll create a pull request of that as well.
