### PR TITLE
Use Forwardable in Rest class to delegate API.

### DIFF
--- a/lib/neography/rest.rb
+++ b/lib/neography/rest.rb
@@ -11,63 +11,109 @@ module Neography
 
     def_delegators :@connection, :configuration
 
-    def initialize(options=ENV['NEO4J_URL'] || {})
+    def initialize(options = ENV['NEO4J_URL'] || {})
       @connection = Connection.new(options)
-
-      @nodes                     = Nodes.new(@connection)
-      @node_properties           = NodeProperties.new(@connection)
-      @node_relationships        = NodeRelationships.new(@connection)
-      @node_indexes              = NodeIndexes.new(@connection)
-      @node_auto_indexes         = NodeAutoIndexes.new(@connection)
-      @node_traversal            = NodeTraversal.new(@connection)
-      @node_paths                = NodePaths.new(@connection)
-
-      @relationships             = Relationships.new(@connection)
-      @relationship_properties   = RelationshipProperties.new(@connection)
-      @relationship_indexes      = RelationshipIndexes.new(@connection)
-      @relationship_auto_indexes = RelationshipAutoIndexes.new(@connection)
-
-      @cypher                    = Cypher.new(@connection)
-      @gremlin                   = Gremlin.new(@connection)
-      @batch                     = Batch.new(@connection)
-      @clean                     = Clean.new(@connection)
-    end
-
-    def get_root
-      @nodes.root
-    end
-
-    def create_node(*args)
-      @nodes.create(*args)
-    end
-
-    def create_nodes(nodes)
-      @nodes.create_multiple(nodes)
-    end
-
-    def create_nodes_threaded(nodes)
-      @nodes.create_multiple_threaded(nodes)
     end
 
     # nodes
+    def_delegator :nodes, :root,                     :get_root
+    def_delegator :nodes, :create,                   :create_node
+    def_delegator :nodes, :create_multiple,          :create_nodes
+    def_delegator :nodes, :create_multiple_threaded, :create_nodes_threaded
+    def_delegator :nodes, :get,                      :get_node
+    def_delegator :nodes, :get_each,                 :get_nodes
+    def_delegator :nodes, :delete,                   :delete_node
 
-    def get_node(id)
-      @nodes.get(id)
-    end
+    # node properties
+    def_delegator :node_properties, :reset,  :reset_node_properties
+    def_delegator :node_properties, :get,    :get_node_properties
+    def_delegator :node_properties, :remove, :remove_node_properties
+    def_delegator :node_properties, :set,    :set_node_properties
 
-    def get_nodes(*nodes)
-      @nodes.get_each(*nodes)
-    end
+    # relationships
+    def_delegator :relationships, :get,    :get_relationship
+    def_delegator :relationships, :delete, :delete_relationship
 
-    #  This is not yet implemented in the REST API
-    #
-    # def get_all_node
-    #   puts "get all nodes"
-    #   get("/nodes/")
-    # end
+    # relationship properties
+    def_delegator :relationship_properties, :reset,  :reset_relationship_properties
+    def_delegator :relationship_properties, :get,    :get_relationship_properties
+    def_delegator :relationship_properties, :remove, :remove_relationship_properties
+    def_delegator :relationship_properties, :set,    :set_relationship_properties
 
-    def delete_node(id)
-      @nodes.delete(id)
+    # node relationships
+    def_delegator :node_relationships, :create, :create_relationship
+    def_delegator :node_relationships, :get, :get_node_relationships
+
+    # node indexes
+    def_delegator :node_indexes, :list,          :list_node_indexes
+    def_delegator :node_indexes, :create,        :create_node_index
+    def_delegator :node_indexes, :create_auto,   :create_node_auto_index
+    def_delegator :node_indexes, :create_unique, :create_unique_node
+    def_delegator :node_indexes, :add,           :add_node_to_index
+    def_delegator :node_indexes, :remove,        :remove_node_from_index
+    def_delegator :node_indexes, :get,           :get_node_index
+    def_delegator :node_indexes, :find,          :find_node_index
+
+    alias_method :list_indexes, :list_node_indexes
+    alias_method :add_to_index, :add_node_to_index
+    alias_method :remove_from_index, :remove_node_from_index
+    alias_method :get_index, :get_node_index
+
+    # auto node indexes
+    def_delegator :node_auto_indexes, :get,             :get_node_auto_index
+    def_delegator :node_auto_indexes, :find_or_query,   :find_node_auto_index
+    def_delegator :node_auto_indexes, :status,          :get_node_auto_index_status
+    def_delegator :node_auto_indexes, :status=,         :set_node_auto_index_status
+    def_delegator :node_auto_indexes, :properties,      :get_node_auto_index_properties
+    def_delegator :node_auto_indexes, :add_property,    :add_node_auto_index_property
+    def_delegator :node_auto_indexes, :remove_property, :remove_node_auto_index_property
+
+    # relationship indexes
+    def_delegator :relationship_indexes, :list,          :list_relationship_indexes
+    def_delegator :relationship_indexes, :create,        :create_relationship_index
+    def_delegator :relationship_indexes, :create_auto,   :create_relationship_auto_index
+    def_delegator :relationship_indexes, :create_unique, :create_unique_relationship
+    def_delegator :relationship_indexes, :add,           :add_relationship_to_index
+    def_delegator :relationship_indexes, :remove,        :remove_relationship_from_index
+    def_delegator :relationship_indexes, :get,           :get_relationship_index
+    def_delegator :relationship_indexes, :find,          :find_relationship_index
+
+    # relationship auto indexes
+    def_delegator :relationship_auto_indexes, :get,             :get_relationship_auto_index
+    def_delegator :relationship_auto_indexes, :find_or_query,   :find_relationship_auto_index
+    def_delegator :relationship_auto_indexes, :status,          :get_relationship_auto_index_status
+    def_delegator :relationship_auto_indexes, :status=,         :set_relationship_auto_index_status
+    def_delegator :relationship_auto_indexes, :properties,      :get_relationship_auto_index_properties
+    def_delegator :relationship_auto_indexes, :add_property,    :add_relationship_auto_index_property
+    def_delegator :relationship_auto_indexes, :remove_property, :remove_relationship_auto_index_property
+
+    # traversal
+    def_delegator :node_traversal, :traverse, :traverse
+
+    # paths
+    def_delegator :node_paths, :get,               :get_path
+    def_delegator :node_paths, :get_all,           :get_paths
+    def_delegator :node_paths, :shortest_weighted, :get_shortest_weighted_path
+
+    # cypher query
+    def_delegator :cypher, :query, :execute_query
+
+    # gremlin script
+    def_delegator :gremlin, :execute, :execute_script
+
+    # batch
+    def_delegator :batch_rest, :execute,        :batch
+    def_delegator :batch_rest, :not_streaming,  :batch_not_streaming
+
+    # For testing (use a separate neo4j instance)
+    # call this before each test or spec
+    def clean_database(sanity_check = "not_really")
+      if sanity_check == "yes_i_really_want_to_clean_the_database"
+        @clean.execute
+        true
+      else
+        false
+      end
     end
 
     def delete_node!(id)
@@ -79,34 +125,6 @@ module Neography
       delete_node(id)
     end
 
-    # node properties
-
-    def reset_node_properties(id, properties)
-      @node_properties.reset(id, properties)
-    end
-
-    def get_node_properties(id, *properties)
-      @node_properties.get(id, *properties.flatten)
-    end
-
-    def remove_node_properties(id, *properties)
-      @node_properties.remove(id, *properties.flatten)
-    end
-
-    def set_node_properties(id, properties)
-      @node_properties.set(id, properties)
-    end
-
-    # relationships
-
-    def get_relationship(id)
-      @relationships.get(id)
-    end
-
-    def delete_relationship(id)
-      @relationships.delete(id)
-    end
-
     def get_relationship_start_node(rel)
       get_node(rel["start"])
     end
@@ -115,219 +133,73 @@ module Neography
       get_node(rel["end"])
     end
 
-    # relationship properties
+    #  This is not yet implemented in the REST API
+    #
+    # def get_all_node
+    #   puts "get all nodes"
+    #   get("/nodes/")
+    # end
 
-    def reset_relationship_properties(id, properties)
-      @relationship_properties.reset(id, properties)
+    private
+
+    def nodes
+      @nodes ||= Nodes.new(@connection)
     end
 
-    def get_relationship_properties(id, *properties)
-      @relationship_properties.get(id, *properties.flatten)
+    def node_properties
+      @node_properties ||= NodeProperties.new(@connection)
     end
 
-    def remove_relationship_properties(id, *properties)
-      @relationship_properties.remove(id, *properties.flatten)
+    def node_relationships
+      @node_relationships ||= NodeRelationships.new(@connection)
     end
 
-    def set_relationship_properties(id, properties)
-      @relationship_properties.set(id, properties)
+    def node_indexes
+      @node_indexes ||= NodeIndexes.new(@connection)
     end
 
-    # node relationships
-
-    def create_relationship(type, from, to, props = nil)
-      @node_relationships.create(type, from, to, props)
+    def node_auto_indexes
+      @node_auto_indexes ||= NodeAutoIndexes.new(@connection)
     end
 
-    def get_node_relationships(id, dir = nil, types = nil)
-      @node_relationships.get(id, dir, types)
+    def node_traversal
+      @node_traversal ||= NodeTraversal.new(@connection)
     end
 
-    # node indexes
-
-    def list_node_indexes
-      @node_indexes.list
-    end
-    alias_method :list_indexes, :list_node_indexes
-
-    def create_node_index(name, type = "exact", provider = "lucene")
-      @node_indexes.create(name, type, provider)
+    def node_paths
+      @node_paths ||= NodePaths.new(@connection)
     end
 
-    def create_node_auto_index(type = "exact", provider = "lucene")
-      @node_indexes.create_auto(type, provider)
+    def relationships
+      @relationships ||= Relationships.new(@connection)
     end
 
-    def add_node_to_index(index, key, value, id)
-      @node_indexes.add(index, key, value, id)
-    end
-    alias_method :add_to_index, :add_node_to_index
-
-    def create_unique_node(index, key, value, props={})
-      @node_indexes.create_unique(index, key, value, props)
+    def relationship_properties
+      @relationship_properties ||= RelationshipProperties.new(@connection)
     end
 
-    def remove_node_from_index(index, id_or_key, id_or_value = nil, id = nil)
-      @node_indexes.remove(index, id_or_key, id_or_value, id)
-    end
-    alias_method :remove_from_index, :remove_node_from_index
-
-    def get_node_index(index, key, value)
-      @node_indexes.get(index, key, value)
-    end
-    alias_method :get_index, :get_node_index
-
-    def find_node_index(index, key_or_query, value = nil)
-      @node_indexes.find(index, key_or_query, value)
+    def relationship_indexes
+      @relationship_indexes ||= RelationshipIndexes.new(@connection)
     end
 
-    # auto node indexes
-
-    def get_node_auto_index(key, value)
-      @node_auto_indexes.get(key, value)
+    def relationship_auto_indexes
+      @relationship_auto_indexes ||= RelationshipAutoIndexes.new(@connection)
     end
 
-    def find_node_auto_index(key_or_query, value = nil)
-      @node_auto_indexes.find_or_query(key_or_query, value)
+    def cypher
+      @cypher ||= Cypher.new(@connection)
     end
 
-    def get_node_auto_index_status
-      @node_auto_indexes.status
+    def gremlin
+      @gremlin ||= Gremlin.new(@connection)
     end
 
-    def set_node_auto_index_status(change_to = true)
-      @node_auto_indexes.status = change_to
+    def batch_rest
+      @batch ||= Batch.new(@connection)
     end
 
-    def get_node_auto_index_properties
-      @node_auto_indexes.properties
-    end
-
-    def add_node_auto_index_property(property)
-      @node_auto_indexes.add_property(property)
-    end
-
-    def remove_node_auto_index_property(property)
-      @node_auto_indexes.remove_property(property)
-    end
-
-    # relationship indexes
-
-    def list_relationship_indexes
-      @relationship_indexes.list
-    end
-
-    def create_relationship_index(name, type = "exact", provider = "lucene")
-      @relationship_indexes.create(name, type, provider)
-    end
-
-    def create_relationship_auto_index(type = "exact", provider = "lucene")
-      @relationship_indexes.create_auto(type, provider)
-    end
-
-    def create_unique_relationship(index, key, value, type, from, to)
-      @relationship_indexes.create_unique(index, key, value, type, from, to)
-    end
-
-    def add_relationship_to_index(index, key, value, id)
-      @relationship_indexes.add(index, key, value, id)
-    end
-
-    def remove_relationship_from_index(index, id_or_key, id_or_value = nil, id = nil)
-      @relationship_indexes.remove(index, id_or_key, id_or_value, id)
-    end
-
-    def get_relationship_index(index, key, value)
-      @relationship_indexes.get(index, key, value)
-    end
-
-    def find_relationship_index(index, key_or_query, value = nil)
-      @relationship_indexes.find(index, key_or_query, value)
-    end
-
-    # relationship auto indexes
-
-    def get_relationship_auto_index(key, value)
-      @relationship_auto_indexes.get(key, value)
-    end
-
-    def find_relationship_auto_index(key_or_query, value = nil)
-      @relationship_auto_indexes.find_or_query(key_or_query, value)
-    end
-
-    def get_relationship_auto_index_status
-      @relationship_auto_indexes.status
-    end
-
-    def set_relationship_auto_index_status(change_to = true)
-      @relationship_auto_indexes.status = change_to
-    end
-
-    def get_relationship_auto_index_properties
-      @relationship_auto_indexes.properties
-    end
-
-    def add_relationship_auto_index_property(property)
-      @relationship_auto_indexes.add_property(property)
-    end
-
-    def remove_relationship_auto_index_property(property)
-      @relationship_auto_indexes.remove_property(property)
-    end
-
-    # traversal
-
-    def traverse(id, return_type, description)
-      @node_traversal.traverse(id, return_type, description)
-    end
-
-    # paths
-
-    def get_path(from, to, relationships, depth = 1, algorithm = "shortestPath")
-      @node_paths.get(from, to, relationships, depth, algorithm)
-    end
-
-    def get_paths(from, to, relationships, depth = 1, algorithm = "allPaths")
-      @node_paths.get_all(from, to, relationships, depth, algorithm)
-    end
-
-    def get_shortest_weighted_path(from, to, relationships, weight_attr = "weight", depth = 1, algorithm = "dijkstra")
-      @node_paths.shortest_weighted(from, to, relationships, weight_attr, depth, algorithm)
-    end
-
-    # cypher query
-
-    def execute_query(query, params = {})
-      @cypher.query(query, params)
-    end
-
-    # gremlin script
-
-    def execute_script(script, params = {})
-      @gremlin.execute(script, params)
-    end
-
-    # batch
-
-    def batch(*args)
-      @batch.execute(*args)
-    end
-
-    def batch_not_streaming(*args)
-      @batch.not_streaming(*args)
-    end
-
-    # clean database
-
-    # For testing (use a separate neo4j instance)
-    # call this before each test or spec
-    def clean_database(sanity_check = "not_really")
-      if sanity_check == "yes_i_really_want_to_clean_the_database"
-        @clean.execute
-        true
-      else
-        false
-      end
+    def clean
+      @clean ||= Clean.new(@connection)
     end
 
   end

--- a/lib/neography/rest/cypher.rb
+++ b/lib/neography/rest/cypher.rb
@@ -7,7 +7,7 @@ module Neography
         @connection = connection
       end
 
-      def query(query, parameters)
+      def query(query, parameters = {})
         options = {
           :body => {
             :query => query,

--- a/lib/neography/rest/gremlin.rb
+++ b/lib/neography/rest/gremlin.rb
@@ -7,7 +7,7 @@ module Neography
         @connection = connection
       end
 
-      def execute(script, parameters)
+      def execute(script, parameters = {})
         options = {
           :body => {
             :script => script,

--- a/lib/neography/rest/indexes.rb
+++ b/lib/neography/rest/indexes.rb
@@ -12,7 +12,7 @@ module Neography
         @connection.get(all_path)
       end
 
-      def create(name, type, provider)
+      def create(name, type = "exact", provider = "lucene")
         options = {
           :body => (
             { :name => name,
@@ -27,7 +27,7 @@ module Neography
         @connection.post(all_path, options)
       end
 
-      def create_auto(type, provider)
+      def create_auto(type = "exact", provider = "lucene")
         create("#{@index_type}_auto_index", type, provider)
       end
 

--- a/lib/neography/rest/node_indexes.rb
+++ b/lib/neography/rest/node_indexes.rb
@@ -17,7 +17,7 @@ module Neography
         super(connection, :node)
       end
 
-      def create_unique(index, key, value, properties)
+      def create_unique(index, key, value, properties = {})
         options = {
           :body => (
             { :properties => properties,

--- a/lib/neography/rest/node_paths.rb
+++ b/lib/neography/rest/node_paths.rb
@@ -11,17 +11,17 @@ module Neography
         @connection = connection
       end
 
-      def get(from, to, relationships, depth, algorithm)
+      def get(from, to, relationships, depth = 1, algorithm = "shortestPath")
         options = path_options(to, relationships, depth, algorithm)
         @connection.post(base_path(:id => get_id(from)), options) || {}
       end
 
-      def get_all(from, to, relationships, depth, algorithm)
+      def get_all(from, to, relationships, depth = 1, algorithm = "allPaths")
         options = path_options(to, relationships, depth, algorithm)
         @connection.post(all_path(:id => get_id(from)), options) || []
       end
 
-      def shortest_weighted(from, to, relationships, weight_attribute, depth, algorithm)
+      def shortest_weighted(from, to, relationships, weight_attribute = "weight", depth = 1, algorithm = "dijkstra")
         options = path_options(to, relationships, depth, algorithm, { :cost_property => weight_attribute })
         @connection.post(all_path(:id => get_id(from)), options) || {}
       end

--- a/lib/neography/rest/node_relationships.rb
+++ b/lib/neography/rest/node_relationships.rb
@@ -12,7 +12,7 @@ module Neography
         @connection = connection
       end
 
-      def create(type, from, to, properties)
+      def create(type, from, to, properties = nil)
         options = {
           :body => {
             :to => @connection.configuration + "/node/#{get_id(to)}",

--- a/lib/neography/rest/properties.rb
+++ b/lib/neography/rest/properties.rb
@@ -28,7 +28,7 @@ module Neography
       end
 
       def get_each(id, *properties)
-        retrieved_properties = properties.inject({}) do |memo, property|
+        retrieved_properties = properties.flatten.inject({}) do |memo, property|
           value = @connection.get(single_path(:id => get_id(id), :property => property))
           memo[property] = value unless value.nil?
           memo
@@ -46,7 +46,7 @@ module Neography
       end
 
       def remove_each(id, *properties)
-        properties.each do |property|
+        properties.flatten.each do |property|
           @connection.delete(single_path(:id => get_id(id), :property => property))
         end
       end


### PR DESCRIPTION
This finalizes all the `Rest` class refactoring. All argument defaults that were in left have been moved into the separate classes. There is hardly any logic left in the `Rest` class, and all API requests are delegated directly to the new classes.
