### PR TITLE
Initialization Hook

### DIFF
--- a/lib/neography/railtie.rb
+++ b/lib/neography/railtie.rb
@@ -3,8 +3,17 @@ require 'rails'
 module Neography
   class Railtie < Rails::Railtie
 
+    # To add an initialization step from your Railtie to Rails boot process, you just need to create an initializer block:
+    # See: http://api.rubyonrails.org/classes/Rails/Railtie.html
+    initializer 'neography.configure' do
+      # Provides a hook so people implementing the gem can do this in a railtie of their own:
+      #   initializer "my_thing.neography_initialization", before: 'neography_railtie.configure_rails_initialization' do
+      #     require 'my_thing/neography'
+      #   end
+    end
+
     rake_tasks do
-      load "neography/tasks.rb"
+      load 'neography/tasks.rb'
     end
   end
 end


### PR DESCRIPTION
Provides a named initialization hook so people depending on the gem can ensure pre-requisite configuration is complete prior to initialization of neography itself.

When I upgraded from 1.0.3 to 1.0.4 I became unable to boot my app, or run my specs due to an error.

```
cannot load such file -- neography/rest/extensions (LoadError)
/Users/pboling/.rvm/gems/ruby-1.9.3-head@simple/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require'
/Users/pboling/.rvm/gems/ruby-1.9.3-head@simple/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `block in require'
/Users/pboling/.rvm/gems/ruby-1.9.3-head@simple/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:236:in `load_dependency'
/Users/pboling/.rvm/gems/ruby-1.9.3-head@simple/gems/activesupport-3.2.11/lib/active_support/dependencies.rb:251:in `require'
/Users/pboling/.rvm/gems/ruby-1.9.3-head@simple/gems/neography-1.0.4/lib/neography/rest.rb:23:in `<top (required)>'
```

With this change I am again able to boot and test my app.  Additionally I can now clean up the way I configure the Neography gem (previously my pre-config had to be in application.rb, ir in an initializer which was ordered alphabetically higher than neography, both of which just feel wrong).
## Example:

```
module Simple
  class NeographyInitialization < Rails::Railtie
    initializer 'simple.neography_initialization', before: 'neography.configure' do
      # require a file where I read from a YAML;
      # load configs for the env into a constant;
      # which is referenced from my Neography configuration in config/initializers
      require 'simple/neography' 
    end
  end
end
```
