### PR TITLE
Accept node hashes in label methods

### DIFF
--- a/lib/neography/rest/node_labels.rb
+++ b/lib/neography/rest/node_labels.rb
@@ -19,7 +19,7 @@ module Neography
       end
 
       def get(id)
-        @connection.get(node_path(:id => id))
+        @connection.get(node_path(:id => get_id(id)))
       end
 
       def get_nodes(label)
@@ -37,7 +37,7 @@ module Neography
           ).to_json,
           :headers => json_content_type
         }
-        @connection.post(node_path(:id => id), options)
+        @connection.post(node_path(:id => get_id(id)), options)
       end
 
       def set(id, label)
@@ -47,11 +47,11 @@ module Neography
           ).to_json,
           :headers => json_content_type
         }
-        @connection.put(node_path(:id => id), options)
+        @connection.put(node_path(:id => get_id(id)), options)
       end
 
       def delete(id, label)
-        @connection.delete(delete_path(:id => id, :label => label))
+        @connection.delete(delete_path(:id => get_id(id), :label => label))
       end
 
 

--- a/spec/integration/rest_labels_spec.rb
+++ b/spec/integration/rest_labels_spec.rb
@@ -16,9 +16,8 @@ describe Neography::Rest do
   describe "add_label" do
     it "can add a label to a node" do
       new_node = @neo.create_node
-      new_node_id = new_node["self"].split('/').last
-      @neo.add_label(new_node_id, "Person")
-      labels = @neo.get_node_labels(new_node_id)
+      @neo.add_label(new_node, "Person")
+      labels = @neo.get_node_labels(new_node)
       labels.should == ["Person"]
     end
 
@@ -51,10 +50,9 @@ describe Neography::Rest do
 
     it "can set a label to a node that already had a label" do
       new_node = @neo.create_node
-      new_node_id = new_node["self"].split('/').last
-      @neo.add_label(new_node_id, "Actor")
-      @neo.set_label(new_node_id, "Director")
-      labels = @neo.get_node_labels(new_node_id)
+      @neo.add_label(new_node, "Actor")
+      @neo.set_label(new_node, "Director")
+      labels = @neo.get_node_labels(new_node)
       labels.should == ["Director"]
     end
 
@@ -70,10 +68,9 @@ describe Neography::Rest do
   describe "delete_label" do
     it "can delete a label from a node" do
       new_node = @neo.create_node
-      new_node_id = new_node["self"].split('/').last
-      @neo.set_label(new_node_id, ["Actor", "Director"])
-      @neo.delete_label(new_node_id, "Actor")
-      labels = @neo.get_node_labels(new_node_id)
+      @neo.set_label(new_node, ["Actor", "Director"])
+      @neo.delete_label(new_node, "Actor")
+      labels = @neo.get_node_labels(new_node)
       labels.should == ["Director"]
     end
 


### PR DESCRIPTION
Currently, adding labels as you would expect to against Neo4J 2 is broken:

```
neo = Neography::Rest.new
node = neo.create_node({})
neo.add_label(node, "Person")
# =>    Neography::NeographyError: Neography::NeographyError
from /home/luke/.gem/gems/neography-1.1.1/lib/neography/connection.rb:195:in `raise_errors'
from /home/luke/.gem/gems/neography-1.1.1/lib/neography/connection.rb:171:in `handle_4xx_500_response'
```

I.e. nondescript error. Looking in the neography log is slightly helpful...

```
Error 405 Method Not Allowed
HTTP ERROR 405
Problem accessing /db/data/node/%7B%22extensions%22=%3E%7B%7D,%20%22labels%22=%3E%22[...]
```

Unlike most Neography methods, add_label and the like don't convert whatever they get to a node ID using get_id(). So, whatever you pass in gets sent off directly in the REST request... a bit surprising.

Modified logic and tests supplied.
