### PR TITLE
Lock rubyzip to 0-9-x-stable

### DIFF
--- a/neography.gemspec
+++ b/neography.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rake", ">= 0.8.7"
   s.add_dependency "json", ">= 1.7.7"
   s.add_dependency "os", ">= 0.9.6"
-  s.add_dependency "rubyzip", ">= 0.9.7"
+  s.add_dependency "rubyzip", "~> 0.9.7"
   s.add_dependency "multi_json", ">= 1.3.2" 
 end


### PR DESCRIPTION
rubyzip has introduced breaking changes on 1.0.0 as per https://github.com/rubyzip/rubyzip/commit/61ce5dbc5f12d2e7d368d480386347b8920897be

Since neography.gemspec uses >= for dependency versions, new installation of dependencies bring rubyzip 1.0.0 and therefore neography breaks.

Here's the output _before_ this fix:

```
$ bundle
$ bundle exec rake

rake aborted!
cannot load such file -- zip/zip
/Users/wagner/Projects/os/neography/lib/neography/tasks.rb:4:in `require'
/Users/wagner/Projects/os/neography/lib/neography/tasks.rb:4:in `<top (required)>'
/Users/wagner/Projects/os/neography/Rakefile:5:in `require'
/Users/wagner/Projects/os/neography/Rakefile:5:in `<top (required)>'
```

And here's the output _after_ this fix:

```
$ bundle exec rake

(hiding verbose output...)

Finished in 12.83 seconds
624 examples, 0 failures
[Coveralls] Outside the Travis environment, not sending data.
```

Since I could only proof the issue with rubyzip, I only changed rubyzip in neography.gemspec. However that'd be nice to make the same change (replacing >= with ~>) for all the other dependencies as well.
