### PR TITLE
Slow query logging for HTTP queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,21 +61,22 @@ Configure Neography as follows:
 ```ruby
 # these are the default values:
 Neography.configure do |config|
-  config.protocol       = "http://"
-  config.server         = "localhost"
-  config.port           = 7474
-  config.directory      = ""  # prefix this path with '/' 
-  config.cypher_path    = "/cypher"
-  config.gremlin_path   = "/ext/GremlinPlugin/graphdb/execute_script"
-  config.log_file       = "neography.log"
-  config.log_enabled    = false
-  config.max_threads    = 20
-  config.authentication = nil  # 'basic' or 'digest'
-  config.username       = nil
-  config.password       = nil
-  config.parser         = MultiJsonParser
-end
-```
+  config.protocol           = "http://"
+  config.server             = "localhost"
+  config.port               = 7474
+  config.directory          = ""  # prefix this path with '/'
+  config.cypher_path        = "/cypher"
+  config.gremlin_path       = "/ext/GremlinPlugin/graphdb/execute_script"
+  config.log_file           = "neography.log"
+  config.log_enabled        = false
+  config.slow_log_threshold = 0    # time in ms for query logging
+  config.max_threads        = 20
+  config.authentication     = nil  # 'basic' or 'digest'
+  config.username           = nil
+  config.password           = nil
+  config.parser             = MultiJsonParser
+  end
+  ```
 
 Then initialize a `Rest` instance:
 

--- a/lib/neography/config.rb
+++ b/lib/neography/config.rb
@@ -3,7 +3,7 @@ module Neography
 
     attr_accessor :protocol, :server, :port, :directory,
       :cypher_path, :gremlin_path,
-      :log_file, :log_enabled,
+      :log_file, :log_enabled, :slow_log_threshold,
       :max_threads,
       :authentication, :username, :password,
       :parser
@@ -14,39 +14,41 @@ module Neography
 
     def to_hash
       {
-        :protocol       => @protocol,
-        :server         => @server,
-        :port           => @port,
-        :directory      => @directory,
-        :cypher_path    => @cypher_path,
-        :gremlin_path   => @gremlin_path,
-        :log_file       => @log_file,
-        :log_enabled    => @log_enabled,
-        :max_threads    => @max_threads,
-        :authentication => @authentication,
-        :username       => @username,
-        :password       => @password,
-        :parser         => @parser
+        :protocol           => @protocol,
+        :server             => @server,
+        :port               => @port,
+        :directory          => @directory,
+        :cypher_path        => @cypher_path,
+        :gremlin_path       => @gremlin_path,
+        :log_file           => @log_file,
+        :log_enabled        => @log_enabled,
+        :slow_log_threshold => @slow_log_threshold,
+        :max_threads        => @max_threads,
+        :authentication     => @authentication,
+        :username           => @username,
+        :password           => @password,
+        :parser             => @parser
       }
     end
 
     private
 
     def set_defaults
-      @protocol       = "http://"
-      @server         = "localhost"
-      @port           = 7474
-      @directory      = ""
-      @cypher_path    = "/cypher"
-      @gremlin_path   = "/ext/GremlinPlugin/graphdb/execute_script"
-      @log_file       = "neography.log"
-      @log_enabled    = false
-      @max_threads    = 20
-      @authentication = nil
-      @username       = nil
-      @password       = nil
-      @parser         = MultiJsonParser
-    end
+      @protocol           = "http://"
+      @server             = "localhost"
+      @port               = 7474
+      @directory          = ""
+      @cypher_path        = "/cypher"
+      @gremlin_path       = "/ext/GremlinPlugin/graphdb/execute_script"
+      @log_file           = "neography.log"
+      @log_enabled        = false
+      @slow_log_threshold = 0
+      @max_threads        = 20
+      @authentication     = nil
+      @username           = nil
+      @password           = nil
+      @parser             = MultiJsonParser
+      end
 
   end
 end

--- a/lib/neography/connection.rb
+++ b/lib/neography/connection.rb
@@ -7,7 +7,7 @@ module Neography
     
     attr_accessor :protocol, :server, :port, :directory,
       :cypher_path, :gremlin_path,
-      :log_file, :log_enabled, :logger,
+      :log_file, :log_enabled, :logger, :slow_log_threshold,
       :max_threads,
       :authentication, :username, :password,
       :parser, :client
@@ -54,7 +54,7 @@ module Neography
         start_time = Time.now
         response = yield
         time = ((Time.now - start_time) * 1000).round(2)
-        @logger.info "[Neography::Query] #{path} #{body} [#{time}ms]"
+        @logger.info "[Neography::Query] #{path} #{body} [#{time}ms]" if time >= slow_log_threshold
         response
       else
         yield
@@ -76,16 +76,17 @@ module Neography
     end
 
     def save_local_configuration(config)
-      @protocol       = config[:protocol]
-      @server         = config[:server]
-      @port           = config[:port]
-      @directory      = config[:directory]
-      @cypher_path    = config[:cypher_path]
-      @gremlin_path   = config[:gremlin_path]
-      @log_file       = config[:log_file]
-      @log_enabled    = config[:log_enabled]
-      @max_threads    = config[:max_threads]
-      @parser         = config[:parser]
+      @protocol           = config[:protocol]
+      @server             = config[:server]
+      @port               = config[:port]
+      @directory          = config[:directory]
+      @cypher_path        = config[:cypher_path]
+      @gremlin_path       = config[:gremlin_path]
+      @log_file           = config[:log_file]
+      @log_enabled        = config[:log_enabled]
+      @slow_log_threshold = config[:slow_log_threshold]
+      @max_threads        = config[:max_threads]
+      @parser             = config[:parser]
 
       @user_agent     = { "User-Agent" => USER_AGENT }
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -7,35 +7,37 @@ module Neography
 
     context "defaults" do
 
-      its(:protocol)       { should == 'http://' }
-      its(:server)         { should == 'localhost' }
-      its(:port)           { should == 7474 }
-      its(:directory)      { should == '' }
-      its(:cypher_path)    { should == '/cypher' }
-      its(:gremlin_path)   { should == '/ext/GremlinPlugin/graphdb/execute_script' }
-      its(:log_file)       { should == 'neography.log' }
-      its(:log_enabled)    { should == false }
-      its(:max_threads)    { should == 20 }
-      its(:authentication) { should == nil }
-      its(:username)       { should == nil }
-      its(:password)       { should == nil }
-      its(:parser)         { should == MultiJsonParser}
+      its(:protocol)           { should == 'http://' }
+      its(:server)             { should == 'localhost' }
+      its(:port)               { should == 7474 }
+      its(:directory)          { should == '' }
+      its(:cypher_path)        { should == '/cypher' }
+      its(:gremlin_path)       { should == '/ext/GremlinPlugin/graphdb/execute_script' }
+      its(:log_file)           { should == 'neography.log' }
+      its(:log_enabled)        { should == false }
+      its(:slow_log_threshold) { should == 0 }
+      its(:max_threads)        { should == 20 }
+      its(:authentication)     { should == nil }
+      its(:username)           { should == nil }
+      its(:password)           { should == nil }
+      its(:parser)             { should == MultiJsonParser}
 
       it "has a hash representation" do
         expected_hash = {
-          :protocol       => 'http://',
-          :server         => 'localhost',
-          :port           => 7474,
-          :directory      => '',
-          :cypher_path    => '/cypher',
-          :gremlin_path   => '/ext/GremlinPlugin/graphdb/execute_script',
-          :log_file       => 'neography.log',
-          :log_enabled    => false,
-          :max_threads    => 20,
-          :authentication => nil,
-          :username       => nil,
-          :password       => nil,
-          :parser         => MultiJsonParser
+          :protocol           => 'http://',
+          :server             => 'localhost',
+          :port               => 7474,
+          :directory          => '',
+          :cypher_path        => '/cypher',
+          :gremlin_path       => '/ext/GremlinPlugin/graphdb/execute_script',
+          :log_file           => 'neography.log',
+          :log_enabled        => false,
+          :slow_log_threshold => 0,
+          :max_threads        => 20,
+          :authentication     => nil,
+          :username           => nil,
+          :password           => nil,
+          :parser             => MultiJsonParser
         }
         config.to_hash.should == expected_hash
       end


### PR DESCRIPTION
1. Added slow_log_threshold option in configuration. Only queries that took more than slow_log_threshold milliseconds will be logged.
2. slow_log_threshold is set to 0 - All queries will be logged by default.
