### PR TITLE
add support for add_label to batch

### DIFF
--- a/lib/neography/rest/batch.rb
+++ b/lib/neography/rest/batch.rb
@@ -112,6 +112,14 @@ module Neography
         end
       end
 
+      # NodeLabel
+
+      def add_label(id, body)
+        post build_node_uri(id) + "/labels" do
+          body
+        end
+      end
+
       # NodeRelationships
 
       def get_node_relationships(id, direction = nil, types = nil)

--- a/spec/unit/rest/batch_spec.rb
+++ b/spec/unit/rest/batch_spec.rb
@@ -105,6 +105,16 @@ module Neography
                         [:reset_node_properties, "index2", { "key2" => "value2" } ]
       end
 
+      it "adds a node label" do
+        expected_body = [
+          { "id" => 0, "method" => "POST", "to" => "{0}/labels", "body" => "foo" },
+          { "id" => 1, "method" => "POST", "to" => "{0}/labels", "body" => "bar" },
+        ]
+        connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        subject.execute [:add_label, "{0}", "foo"],
+                        [:add_label, "{0}", "bar"]
+      end
+
       it "gets node relationships" do
         expected_body = [
           { "id" => 0, "method" => "GET", "to" => "/node/id1/relationships/direction1" },


### PR DESCRIPTION
Unfortunately, while this works fine with create_node, it doesn't work with create_unique_node. The server reports an error: '...connection.rb:202:in 'raise_errors': Not Found (Neography::NeographyError)...'
