### PR TITLE
Allow to pass extra configuration options when creating indexes

### DIFF
--- a/lib/neography/rest.rb
+++ b/lib/neography/rest.rb
@@ -268,8 +268,8 @@ module Neography
     end
     alias_method :list_indexes, :list_node_indexes
 
-    def create_node_index(name, type = "exact", provider = "lucene")
-      @node_indexes.create(name, type, provider)
+    def create_node_index(name, type = "exact", provider = "lucene", extra_config = nil)
+      @node_indexes.create(name, type, provider, extra_config)
     end
 
     def create_node_auto_index(type = "exact", provider = "lucene")

--- a/lib/neography/rest/batch.rb
+++ b/lib/neography/rest/batch.rb
@@ -54,13 +54,15 @@ module Neography
 
       # NodeIndexes
 
-      def create_node_index(name, type = "exact", provider = "lucene")
+      def create_node_index(name, type = "exact", provider = "lucene", extra_config = nil)
+        config = {
+          :type => type,
+          :provider => provider
+        }
+        config.merge!(extra_config) unless extra_config.nil?
         post NodeIndexes.all_path do
           { :name => name,
-            :config => {
-              :type => type,
-              :provider => provider
-            }
+            :config => config
           }
         end
       end

--- a/lib/neography/rest/indexes.rb
+++ b/lib/neography/rest/indexes.rb
@@ -12,14 +12,16 @@ module Neography
         @connection.get(all_path)
       end
 
-      def create(name, type = "exact", provider = "lucene")
+      def create(name, type = "exact", provider = "lucene", extra_config = nil)
+        config = {
+          :type => type,
+          :provider => provider
+        }
+        config.merge!(extra_config) unless extra_config.nil?
         options = {
           :body => (
             { :name => name,
-              :config => {
-                :type => type,
-                :provider => provider
-              }
+              :config => config
             }
           ).to_json,
           :headers => json_content_type

--- a/spec/integration/rest_index_spec.rb
+++ b/spec/integration/rest_index_spec.rb
@@ -44,6 +44,16 @@ describe Neography::Rest do
       new_index["type"].should == "fulltext"
     end
 
+    it "can create a node index with extra configuration options" do
+      name = generate_text(6)
+      new_index = @neo.create_node_index(name, "fulltext","lucene", extra: 'extra-value')
+      new_index.should_not be_nil
+      new_index["template"].should == "#{@neo.configuration}/index/node/#{name}/{key}/{value}"
+      new_index["provider"].should == "lucene"
+      new_index["extra"].should == "extra-value"
+      new_index["type"].should == "fulltext"
+    end
+
     it "can create a relationship index" do
       name = generate_text(6)
       new_index = @neo.create_relationship_index(name)


### PR DESCRIPTION
This allows clients to specify custom lucene analyzers and possibly tweak
the indexes with future options provided by neo4j/lucene. The current ones
can be seen at http://docs.neo4j.org/chunked/stable/indexing-create-advanced.html
