### PR TITLE
Avoid waiting for a WWW-Authenticate under HTTP Basic auth

### DIFF
--- a/lib/neography/connection.rb
+++ b/lib/neography/connection.rb
@@ -66,9 +66,18 @@ module Neography
     end
 
     def authenticate(path = nil)
-      @client.set_auth(path, 
-                       @authentication[@authentication.keys.first][:username], 
-                       @authentication[@authentication.keys.first][:password]) unless @authentication.empty?
+      unless @authentication.empty?
+        auth_type = @authentication.keys.first
+        @client.set_auth(
+          path,
+          @authentication[auth_type][:username],
+          @authentication[auth_type][:password]
+        )
+        # Force http client to always send auth credentials without
+        # waiting for WWW-Authenticate headers, thus saving one request
+        # roundtrip for each URI. Only works for HTTP basic auth.
+        @client.www_auth.basic_auth.challenge(configuration) if auth_type == 'basic_auth'
+      end
     end
     
     private


### PR DESCRIPTION
HTTPClient doesn't send any credentials unless it has seen a previous
challenge for the requested URL in the form of a WWW-Authenticate
header. Such challenge is sent by the server after it receives an
unauthenticated request to such URL. The wasted roundtrip wouldn't
be too bad if it were limited to the first request. However,
httpclient only remembers the challenge for each individual URL and
their 'child' URLs. This means that, for example, HTTP requests to
/db/data/node/<X> will probably incur in a new wasteful rountrip
for each different value of <X>.

The fix makes httpclient think that it has received a challenge
for the root URL of the neo4j server.
