### PR TITLE
Raise Neography::UnknownBatchOptionException when bad option is passed in batch

### DIFF
--- a/lib/neography/errors.rb
+++ b/lib/neography/errors.rb
@@ -51,4 +51,7 @@ module Neography
   # Signals that a deadlock between two or more transactions has been detected
   class DeadlockDetectedException < NeographyError; end
 
+  # Unknown batch option exception detected
+  class UnknownBatchOptionException < NeographyError; end
+
 end

--- a/lib/neography/rest/batch.rb
+++ b/lib/neography/rest/batch.rb
@@ -25,7 +25,7 @@ module Neography
         begin
           send("batch_#{args[0]}".to_sym, *args[1..-1])
         rescue
-          raise "Unknown option #{args[0]} - #{args}"
+          raise UnknownBatchOptionException.new("Unknown option #{args[0]} - #{args}")
         end
       end
 

--- a/spec/integration/rest_batch_spec.rb
+++ b/spec/integration/rest_batch_spec.rb
@@ -566,4 +566,18 @@ describe Neography::Rest do
     end
   end
 
+  describe "batch unknown option" do
+    it "should raise Neography::UnknownBatchOptionException when bad option is passed in batch" do
+      batch_commands = []
+
+      batch_commands << [ :bad_option, "start person_n=node:person(ssn = '000-00-0002')
+                                           set bar1 = {foo}"]
+
+      expect {
+        batch_result = @neo.batch *batch_commands
+      }.to raise_exception Neography::UnknownBatchOptionException
+
+    end
+  end
+
 end


### PR DESCRIPTION
Raise Neography::UnknownBatchOptionException when bad option is passed in batch.
