### PR TITLE
Fix: NotFoundException being thrown instead of a ParameterNotFoundException

### DIFF
--- a/lib/neography/connection.rb
+++ b/lib/neography/connection.rb
@@ -234,6 +234,7 @@ module Neography
         when /NodeNotFoundException/         ; NodeNotFoundException
         when /NoSuchPropertyException/       ; NoSuchPropertyException
         when /RelationshipNotFoundException/ ; RelationshipNotFoundException
+        when /ParameterNotFoundException/    ; ParameterNotFoundException
         when /NotFoundException/             ; NotFoundException
         when /UniquePathNotUniqueException/  ; UniquePathNotUniqueException
         when /DeadlockDetectedException/     ; DeadlockDetectedException

--- a/lib/neography/errors.rb
+++ b/lib/neography/errors.rb
@@ -54,4 +54,7 @@ module Neography
   # Unknown batch option exception detected
   class UnknownBatchOptionException < NeographyError; end
 
+  # A Cypher query is using a parameter that is not supplied
+  class ParameterNotFoundException < NeographyError; end
+
 end

--- a/spec/integration/rest_batch_spec.rb
+++ b/spec/integration/rest_batch_spec.rb
@@ -330,6 +330,13 @@ describe Neography::Rest do
       batch_result.first["body"]["data"][0][0]["self"].split('/').last.should == id
     end
 
+    it "raises ParameterNotFoundException when a cypher parameter is missing and ORDER BY is used" do
+      q = "MATCH n WHERE n.x>{missing_parameter} RETURN n ORDER BY n"
+      expect{
+        @neo.batch [:execute_query, q, {}]
+      }.to raise_error Neography::ParameterNotFoundException
+    end
+
   	it "can delete a node in batch" do
   		node1 = @neo.create_node
   		node2 = @neo.create_node


### PR DESCRIPTION
The regexp for a `NotFoundException` was also matching `ParameterNotFoundException`s. This PR fixes that. While investigating, I found some weird behaviour I don't quite understand though. Let me know if I should repost the following as a neo4j issue, or if I'm just doing it wrong ;-)

The neo4j responses when a parameter of a cypher query is missing are a little confusing. In all of the three following cases I would expect a `ParameterNotFoundException`, but neo4j is behaving differently for each query.

Let's take a query that uses `ORDER BY` but with a parameter missing:

``` shell
curl -XPOST -d'{"query":"MATCH n WHERE n.foo={missing_param} RETURN n ORDER BY n.bar","params":{}}' -H'Content-Type:application/json' -H'Accept:application/json;xxstream=true;charset=UTF-8'  http://localhost:7474/db/data/cypher
```

Throws a `ParameterNotFoundException` as expected.

Now, if we take the same query but leave out the `ORDER BY` clause, we get a `BadInputException`:

``` shell
curl -XPOST -d'{"query":"MATCH n WHERE n.foo={missing_param} RETURN n","params":{}}' -H'Content-Type:application/json' -H'Accept:application/json;xxstream=true;charset=UTF-8'  http://localhost:7474/db/data/cypher
```

If, however, we express the query differently:

``` shell
curl -XPOST -d'{"query":"MATCH (n:Foo{bar:{missing_param}}) RETURN n ORDER BY n.bar","params":{}}' -H'Content-Type:application/json' -H'Accept:application/json;xxstream=true;charset=UTF-8'  http://localhost:7474/db/data/cypher
```

we just get an empty result set with _no exception_.
