### PR TITLE
Convert specs to RSpec 2.14.8 syntax and fix broken array equality check in rest_index_spec

### DIFF
--- a/spec/integration/authorization_spec.rb
+++ b/spec/integration/authorization_spec.rb
@@ -6,7 +6,7 @@ describe Neography::Rest, :slow => true do
       it "can get the root node"do
         @neo = Neography::Rest.new({:authentication => 'digest', :username => "username", :password => "password"})
         root_node = @neo.get_root
-        root_node.should have_key("reference_node")
+        expect(root_node).to have_key("reference_node")
       end
     end    
     
@@ -14,7 +14,7 @@ describe Neography::Rest, :slow => true do
       it "can create an empty node" do
         @neo = Neography::Rest.new({:authentication => 'basic', :username => "username", :password => "password"})
         new_node = @neo.create_node
-        new_node.should_not be_nil
+        expect(new_node).not_to be_nil
       end
     end
 
@@ -22,7 +22,7 @@ describe Neography::Rest, :slow => true do
       it "can create an empty node" do
         @neo = Neography::Rest.new("http://username:password@localhost:7474")
         new_node = @neo.create_node
-        new_node.should_not be_nil
+        expect(new_node).not_to be_nil
       end
     end
   end
@@ -32,7 +32,7 @@ describe Neography::Rest, :slow => true do
       it "can create an empty node" do
         @neo = Neography::Rest.new({:authentication => 'digest', :username => "username", :password => "password"})
         new_node = @neo.create_node
-        new_node.should_not be_nil
+        expect(new_node).not_to be_nil
       end
     end
   end

--- a/spec/integration/broken_spatial_spec.rb
+++ b/spec/integration/broken_spatial_spec.rb
@@ -17,12 +17,12 @@ describe Neography::Rest do
       # getting "The transaction is marked for rollback only." errors
       # possibly related to a Cypher Transaction Bug.
       puts batch_result.inspect
-      batch_result[0].first["data"]["layer"].should == "restaurantsbatch"
-      batch_result[1].first["data"]["lat"].should == properties[:lat]
-      batch_result[1].first["data"]["lon"].should == properties[:lon]
-      batch_result[2].first["data"]["layer"].should == "restaurantsbatch"
-      batch_result[3].first["data"].should_not be_empty
-      batch_result[4].first["data"].should_not be_empty
+      expect(batch_result[0].first["data"]["layer"]).to eq("restaurantsbatch")
+      expect(batch_result[1].first["data"]["lat"]).to eq(properties[:lat])
+      expect(batch_result[1].first["data"]["lon"]).to eq(properties[:lon])
+      expect(batch_result[2].first["data"]["layer"]).to eq("restaurantsbatch")
+      expect(batch_result[3].first["data"]).not_to be_empty
+      expect(batch_result[4].first["data"]).not_to be_empty
     end
   end
 end

--- a/spec/integration/index_spec.rb
+++ b/spec/integration/index_spec.rb
@@ -30,7 +30,7 @@ describe Neography::Index do
     new_node = Neography::Node.create("name" => value)
     new_node.add_to_index("node_test_index", "name", value)
     existing_node = Neography::Node.find("node_test_index", "name", value)
-    existing_node.name.should == value
+    expect(existing_node.name).to eq(value)
   end
 
   it "can find a node in an index with brackets" do
@@ -39,7 +39,7 @@ describe Neography::Index do
     new_node = Neography::Node.create("name" => value)
     new_node.add_to_index(key, "name", value)
     existing_node = Neography::Node.find(key, "name", value)
-    existing_node.name.should == value
+    expect(existing_node.name).to eq(value)
   end
 
   it "can find a relationship in an index" do
@@ -49,7 +49,7 @@ describe Neography::Index do
     r = Neography::Relationship.create(:friends, node1, node2, {"name" => value})
     r.add_to_index("relationship_test_index", "name", value)
     existing_r = Neography::Relationship.find("relationship_test_index", "name", value)
-    existing_r.name.should == value
+    expect(existing_r.name).to eq(value)
   end
 
   it "can find multiple nodes in an index" do
@@ -62,9 +62,9 @@ describe Neography::Index do
     node2.add_to_index("node_test_index", "first_name", value1)
 
     existing_nodes = Neography::Node.find("node_test_index", "first_name", value1)
-    existing_nodes.size.should == 2
-    existing_nodes.first.last_name.should == value2
-    existing_nodes.last.last_name.should == value3
+    expect(existing_nodes.size).to eq(2)
+    expect(existing_nodes.first.last_name).to eq(value2)
+    expect(existing_nodes.last.last_name).to eq(value3)
   end
 
 

--- a/spec/integration/neography_spec.rb
+++ b/spec/integration/neography_spec.rb
@@ -4,7 +4,7 @@ describe Neography do
   describe "ref_node", :reference => true do
     it "can get the reference node" do
       root_node = Neography.ref_node
-      root_node.should have_key("self")
+      expect(root_node).to have_key("self")
     end
   end
 end

--- a/spec/integration/node_encoding_spec.rb
+++ b/spec/integration/node_encoding_spec.rb
@@ -7,13 +7,13 @@ describe Neography::Node do
 
     it "can create a node with UTF-8 encoded properties" do
       new_node = Neography::Node.create("name" => "美都池水")
-      new_node.name.should == "美都池水"
+      expect(new_node.name).to eq("美都池水")
     end
 
     it "can create a node with more than one UTF-8 encoded properties" do
       new_node = Neography::Node.create("first_name" => "美都", "last_name" => "池水")
-      new_node.first_name.should == "美都"
-      new_node.last_name.should == "池水"
+      expect(new_node.first_name).to eq("美都")
+      expect(new_node.last_name).to eq("池水")
     end
 
   end
@@ -22,11 +22,11 @@ describe Neography::Node do
     it "can get a node with UTF-8 encoded properties that exists" do
       new_node = Neography::Node.create("first_name" => "美都", "last_name" => "池水")
       existing_node = Neography::Node.load(new_node)
-      existing_node.should_not be_nil
-      existing_node.neo_id.should_not be_nil
-      existing_node.neo_id.should == new_node.neo_id
-      existing_node.first_name.should == "美都"
-      existing_node.last_name.should == "池水"
+      expect(existing_node).not_to be_nil
+      expect(existing_node.neo_id).not_to be_nil
+      expect(existing_node.neo_id).to eq(new_node.neo_id)
+      expect(existing_node.first_name).to eq("美都")
+      expect(existing_node.last_name).to eq("池水")
     end
 
     it "can get a node with UTF-8 encoded properties from an index" do
@@ -37,11 +37,11 @@ describe Neography::Node do
       @neo.add_node_to_index("test_node_index", key, value, new_node)
       node_from_index = @neo.get_node_index("test_node_index", key, value)
       existing_node = Neography::Node.load(node_from_index)
-      existing_node.should_not be_nil
-      existing_node.neo_id.should_not be_nil
-      existing_node.neo_id.should == new_node.neo_id
-      existing_node.first_name.should == "美都"
-      existing_node.last_name.should == "池水"
+      expect(existing_node).not_to be_nil
+      expect(existing_node.neo_id).not_to be_nil
+      expect(existing_node.neo_id).to eq(new_node.neo_id)
+      expect(existing_node.first_name).to eq("美都")
+      expect(existing_node.last_name).to eq("池水")
     end
 
     it "can get a node with UTF-8 encoded properties that exists via cypher" do
@@ -50,11 +50,11 @@ describe Neography::Node do
       @neo = Neography::Rest.new
       results = @neo.execute_query(cypher, {:id => new_node.neo_id.to_i})
       existing_node = Neography::Node.load(results)
-      existing_node.should_not be_nil
-      existing_node.neo_id.should_not be_nil
-      existing_node.neo_id.should == new_node.neo_id
-      existing_node.first_name.should == "美都"
-      existing_node.last_name.should == "池水"
+      expect(existing_node).not_to be_nil
+      expect(existing_node.neo_id).not_to be_nil
+      expect(existing_node.neo_id).to eq(new_node.neo_id)
+      expect(existing_node.first_name).to eq("美都")
+      expect(existing_node.last_name).to eq("池水")
     end
 
     it "can get columns of data from a node with UTF-8 encoded properties that exists via cypher" do
@@ -63,7 +63,7 @@ describe Neography::Node do
                     RETURN me.first_name, me.last_name"
       @neo = Neography::Rest.new
       results = @neo.execute_query(cypher, {:id => new_node.neo_id.to_i})
-      results['data'][0].should == ["美都","池水"]
+      expect(results['data'][0]).to eq(["美都","池水"])
     end
 
   end

--- a/spec/integration/node_path_spec.rb
+++ b/spec/integration/node_path_spec.rb
@@ -21,8 +21,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.all_paths_to(mary).incoming(:friends).depth(4).nodes.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_true}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_false}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_true}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_false}
       end
     end
 
@@ -30,8 +30,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.all_paths_to(mary).incoming(:friends).depth(4).rels.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_false}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_true}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_false}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_true}
       end
     end
 
@@ -41,9 +41,9 @@ describe Neography::NodePath do
       johnathan.all_paths_to(mary).incoming(:friends).depth(4).each do |path|
         path.each_with_index do  |n,i| 
           if i.even?
-            n.is_a?(Neography::Node).should be_true
+            expect(n.is_a?(Neography::Node)).to be_true
           else
-            n.is_a?(Neography::Relationship).should be_true 
+            expect(n.is_a?(Neography::Relationship)).to be_true 
           end
         end
       end
@@ -55,8 +55,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.all_simple_paths_to(mary).incoming(:friends).depth(4).nodes.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_true}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_false}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_true}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_false}
       end
     end
 
@@ -64,8 +64,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.all_simple_paths_to(mary).incoming(:friends).depth(4).rels.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_false}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_true}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_false}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_true}
       end
     end
 
@@ -75,9 +75,9 @@ describe Neography::NodePath do
       johnathan.all_simple_paths_to(mary).incoming(:friends).depth(4).each do |path|
         path.each_with_index do  |n,i| 
           if i.even?
-            n.is_a?(Neography::Node).should be_true
+            expect(n.is_a?(Neography::Node)).to be_true
           else
-            n.is_a?(Neography::Relationship).should be_true 
+            expect(n.is_a?(Neography::Relationship)).to be_true 
           end
         end
       end
@@ -89,8 +89,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.all_shortest_paths_to(mary).incoming(:friends).depth(4).nodes.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_true}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_false}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_true}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_false}
       end
     end
 
@@ -98,8 +98,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.all_shortest_paths_to(mary).incoming(:friends).depth(4).rels.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_false}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_true}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_false}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_true}
       end
     end
 
@@ -109,9 +109,9 @@ describe Neography::NodePath do
       johnathan.all_shortest_paths_to(mary).incoming(:friends).depth(4).each do |path|
         path.each_with_index do  |n,i| 
           if i.even?
-            n.is_a?(Neography::Node).should be_true
+            expect(n.is_a?(Neography::Node)).to be_true
           else
-            n.is_a?(Neography::Relationship).should be_true 
+            expect(n.is_a?(Neography::Relationship)).to be_true 
           end
         end
       end
@@ -123,8 +123,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.path_to(mary).incoming(:friends).depth(4).nodes.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_true}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_false}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_true}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_false}
       end
     end
 
@@ -132,8 +132,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.path_to(mary).incoming(:friends).depth(4).rels.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_false}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_true}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_false}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_true}
       end
     end
 
@@ -143,9 +143,9 @@ describe Neography::NodePath do
       johnathan.path_to(mary).incoming(:friends).depth(4).each do |path|
         path.each_with_index do  |n,i| 
           if i.even?
-            n.is_a?(Neography::Node).should be_true
+            expect(n.is_a?(Neography::Node)).to be_true
           else
-            n.is_a?(Neography::Relationship).should be_true 
+            expect(n.is_a?(Neography::Relationship)).to be_true 
           end
         end
       end
@@ -157,8 +157,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.simple_path_to(mary).incoming(:friends).depth(4).nodes.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_true}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_false}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_true}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_false}
       end
     end
 
@@ -166,8 +166,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.simple_path_to(mary).incoming(:friends).depth(4).rels.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_false}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_true}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_false}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_true}
       end
     end
 
@@ -177,9 +177,9 @@ describe Neography::NodePath do
       johnathan.simple_path_to(mary).incoming(:friends).depth(4).each do |path|
         path.each_with_index do  |n,i| 
           if i.even?
-            n.is_a?(Neography::Node).should be_true
+            expect(n.is_a?(Neography::Node)).to be_true
           else
-            n.is_a?(Neography::Relationship).should be_true 
+            expect(n.is_a?(Neography::Relationship)).to be_true 
           end
         end
       end
@@ -191,8 +191,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.shortest_path_to(mary).incoming(:friends).depth(4).nodes.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_true}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_false}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_true}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_false}
       end
     end
 
@@ -200,8 +200,8 @@ describe Neography::NodePath do
       johnathan, mark, phill, mary = create_nodes
 
       johnathan.shortest_path_to(mary).incoming(:friends).depth(4).rels.each do |path|
-         path.map{|n| n.is_a?(Neography::Node).should be_false}
-         path.map{|n| n.is_a?(Neography::Relationship).should be_true}
+         path.map{|n| expect(n.is_a?(Neography::Node)).to be_false}
+         path.map{|n| expect(n.is_a?(Neography::Relationship)).to be_true}
       end
     end
 
@@ -211,9 +211,9 @@ describe Neography::NodePath do
       johnathan.shortest_path_to(mary).incoming(:friends).depth(4).each do |path|
         path.each_with_index do  |n,i| 
           if i.even?
-            n.is_a?(Neography::Node).should be_true
+            expect(n.is_a?(Neography::Node)).to be_true
           else
-            n.is_a?(Neography::Relationship).should be_true 
+            expect(n.is_a?(Neography::Relationship)).to be_true 
           end
         end
       end

--- a/spec/integration/node_relationship_spec.rb
+++ b/spec/integration/node_relationship_spec.rb
@@ -38,7 +38,7 @@ describe Neography::NodeRelationship do
       a.outgoing(:friends) << other_node
 
       # then
-      a.outgoing(:friends).first.should == other_node
+      expect(a.outgoing(:friends).first).to eq(other_node)
     end
 
     it "#outgoing(:friends) << b << c creates an outgoing relationship of type :friends" do
@@ -50,46 +50,46 @@ describe Neography::NodeRelationship do
       a.outgoing(:friends) << b << c
 
       # then
-      a.outgoing(:friends).should include(b,c)
+      expect(a.outgoing(:friends)).to include(b,c)
     end
 
     it "#outgoing returns all incoming nodes of any type" do
       a,b,c,d,e,f = create_nodes
 
-      b.outgoing.should include(c,f,d)
-      [*b.outgoing].size.should == 4 #c is related by both work and friends
+      expect(b.outgoing).to include(c,f,d)
+      expect([*b.outgoing].size).to eq(4) #c is related by both work and friends
     end
 
     it "#outgoing(type) should only return outgoing nodes of the given type of depth one" do
       a,b,c,d = create_nodes
-      b.outgoing(:work).should include(c,d)
-      [*b.outgoing(:work)].size.should == 2
+      expect(b.outgoing(:work)).to include(c,d)
+      expect([*b.outgoing(:work)].size).to eq(2)
     end
 
     it "#outgoing(type1).outgoing(type2) should return outgoing nodes of the given types" do
       a,b,c,d,e,f = create_nodes
       nodes = b.outgoing(:work).outgoing(:friends)
      
-      nodes.should include(c,d,f)
-      nodes.size.should == 4 #c is related by both work and friends
+      expect(nodes).to include(c,d,f)
+      expect(nodes.size).to eq(4) #c is related by both work and friends
     end
 
     it "#outgoing(type).depth(4) should only return outgoing nodes of the given type and depth" do
       a,b,c,d,e = create_nodes
-      [*b.outgoing(:work).depth(4)].size.should == 3
-      b.outgoing(:work).depth(4).should include(c,d,e)
+      expect([*b.outgoing(:work).depth(4)].size).to eq(3)
+      expect(b.outgoing(:work).depth(4)).to include(c,d,e)
     end
 
     it "#outgoing(type).depth(4).include_start_node should also include the start node" do
       a,b,c,d,e = create_nodes
-      [*b.outgoing(:work).depth(4).include_start_node].size.should == 4
-      b.outgoing(:work).depth(4).include_start_node.should include(b,c,d,e)
+      expect([*b.outgoing(:work).depth(4).include_start_node].size).to eq(4)
+      expect(b.outgoing(:work).depth(4).include_start_node).to include(b,c,d,e)
     end
 
     it "#outgoing(type).depth(:all) should traverse at any depth" do
       a,b,c,d,e = create_nodes
-      [*b.outgoing(:work).depth(:all)].size.should == 3
-      b.outgoing(:work).depth(:all).should include(c,d,e)
+      expect([*b.outgoing(:work).depth(:all)].size).to eq(3)
+      expect(b.outgoing(:work).depth(:all)).to include(c,d,e)
     end
   end
 
@@ -102,7 +102,7 @@ describe Neography::NodeRelationship do
       a.incoming(:friends) << other_node
 
       # then
-      a.incoming(:friends).first.should == other_node
+      expect(a.incoming(:friends).first).to eq(other_node)
     end
 
     it "#incoming(:friends) << b << c creates an incoming relationship of type :friends" do
@@ -114,26 +114,26 @@ describe Neography::NodeRelationship do
       a.incoming(:friends) << b << c
 
       # then
-      a.incoming(:friends).should include(b,c)
+      expect(a.incoming(:friends)).to include(b,c)
     end
 
     it "#incoming returns all incoming nodes of any type" do
       a,b,c,d,e,f = create_nodes
 
-      b.incoming.should include(a)
-      [*b.incoming].size.should == 1
+      expect(b.incoming).to include(a)
+      expect([*b.incoming].size).to eq(1)
     end
 
     it "#incoming(type).depth(2) should only return outgoing nodes of the given type and depth" do
       a,b,c,d,e = create_nodes
-      [*e.incoming(:work).depth(2)].size.should == 2
-      e.incoming(:work).depth(2).should include(b,d)
+      expect([*e.incoming(:work).depth(2)].size).to eq(2)
+      expect(e.incoming(:work).depth(2)).to include(b,d)
     end
 
     it "#incoming(type) should only return incoming nodes of the given type of depth one" do
       a,b,c,d = create_nodes
-      c.incoming(:work).should include(b)
-      [*c.incoming(:work)].size.should == 1
+      expect(c.incoming(:work)).to include(b)
+      expect([*c.incoming(:work)].size).to eq(1)
     end
   end
 
@@ -144,37 +144,37 @@ describe Neography::NodeRelationship do
 
       # when
       a.both(:friends) << other_node
-      a.incoming(:friends).first.should == other_node
-      a.outgoing(:friends).first.should == other_node
+      expect(a.incoming(:friends).first).to eq(other_node)
+      expect(a.outgoing(:friends).first).to eq(other_node)
     end
 
     it "#both returns all incoming and outgoing nodes of any type" do
       a,b,c,d,e,f = create_nodes
 
-      b.both.should include(a,c,d,f)
-      [*b.both].size.should == 5 #c is related by both work and friends
-      b.incoming.should include(a)
-      b.outgoing.should include(c)
+      expect(b.both).to include(a,c,d,f)
+      expect([*b.both].size).to eq(5) #c is related by both work and friends
+      expect(b.incoming).to include(a)
+      expect(b.outgoing).to include(c)
     end
 
     it "#both returns an empty array for unconnected nodes" do
       a = Neography::Node.create
-      a.both.size.should == 0
+      expect(a.both.size).to eq(0)
     end
 
     it "#both(type) should return both incoming and outgoing nodes of the given type of depth one" do
       a,b,c,d,e,f = create_nodes
 
-      b.both(:friends).should include(a,c,f)
-      [*b.both(:friends)].size.should == 3
+      expect(b.both(:friends)).to include(a,c,f)
+      expect([*b.both(:friends)].size).to eq(3)
     end
 
     it "#outgoing and #incoming can be combined to traverse several relationship types" do
       a,b,c,d,e = create_nodes
       nodes = [*b.incoming(:friends).outgoing(:work)]
 
-      nodes.should include(a,c,d)
-      nodes.should_not include(b,e)
+      expect(nodes).to include(a,c,d)
+      expect(nodes).not_to include(b,e)
     end
   end
 
@@ -182,22 +182,22 @@ describe Neography::NodeRelationship do
   describe "prune" do
     it "#prune, if it returns true the traversal will be stop for that path" do
       a, b, c, d, e = create_nodes
-      [*b.outgoing(:work).depth(4)].size.should == 3
-      b.outgoing(:work).depth(4).should include(c,d,e)
+      expect([*b.outgoing(:work).depth(4)].size).to eq(3)
+      expect(b.outgoing(:work).depth(4)).to include(c,d,e)
 
-      [*b.outgoing(:work).prune("position.endNode().getProperty('name') == 'd';")].size.should == 2
-      b.outgoing(:work).prune("position.endNode().getProperty('name') == 'd';").should include(c,d)
+      expect([*b.outgoing(:work).prune("position.endNode().getProperty('name') == 'd';")].size).to eq(2)
+      expect(b.outgoing(:work).prune("position.endNode().getProperty('name') == 'd';")).to include(c,d)
     end
   end
 
   describe "filter" do
     it "#filter, if it returns true the node will be included in the return results" do
       a, b, c, d, e = create_nodes
-      [*b.outgoing(:work).depth(4)].size.should == 3
-      b.outgoing(:work).depth(4).should include(c,d,e)
+      expect([*b.outgoing(:work).depth(4)].size).to eq(3)
+      expect(b.outgoing(:work).depth(4)).to include(c,d,e)
 
-      [*b.outgoing(:work).depth(4).filter("position.length() == 2;")].size.should == 1
-      b.outgoing(:work).depth(4).filter("position.length() == 2;").should include(e)
+      expect([*b.outgoing(:work).depth(4).filter("position.length() == 2;")].size).to eq(1)
+      expect(b.outgoing(:work).depth(4).filter("position.length() == 2;")).to include(e)
     end
   end
 
@@ -209,8 +209,8 @@ describe Neography::NodeRelationship do
       r1 = Neography::Relationship.create(:friend, a, b)
       Neography::Relationship.create(:friend, a, c)
 
-      a.rels.to_other(b).size.should == 1
-      a.rels.to_other(b).should include(r1)
+      expect(a.rels.to_other(b).size).to eq(1)
+      expect(a.rels.to_other(b)).to include(r1)
     end
 
     it "#rels returns an RelationshipTraverser which provides a method for deleting all the relationships" do
@@ -220,11 +220,11 @@ describe Neography::NodeRelationship do
       r1 = Neography::Relationship.create(:friend, a, b)
       r2 = Neography::Relationship.create(:friend, a, c)
 
-      a.rel?(:friend).should be_true
+      expect(a.rel?(:friend)).to be_true
       a.rels.del
-      a.rel?(:friend).should be_false
-      r1.exist?.should be_false
-      r2.exist?.should be_false
+      expect(a.rel?(:friend)).to be_false
+      expect(r1.exist?).to be_false
+      expect(r2.exist?).to be_false
     end
 
     it "#rels returns an RelationshipTraverser with methods #del and #to_other which can be combined to only delete a subset of the relationships" do
@@ -233,19 +233,19 @@ describe Neography::NodeRelationship do
       c = Neography::Node.create
       r1 = Neography::Relationship.create(:friend, a, b)
       r2 = Neography::Relationship.create(:friend, a, c)
-      r1.exist?.should be_true
-      r2.exist?.should be_true
+      expect(r1.exist?).to be_true
+      expect(r2.exist?).to be_true
       a.rels.to_other(c).del
-      r1.exist?.should be_true
-      r2.exist?.should be_false
+      expect(r1.exist?).to be_true
+      expect(r2.exist?).to be_false
     end
 
  it "#rels should return both incoming and outgoing relationship of any type of depth one" do
       a,b,c,d,e,f = create_nodes
-      b.rels.size.should == 5
+      expect(b.rels.size).to eq(5)
       nodes = b.rels.collect{|r| r.other_node(b)}
-      nodes.should include(a,c,d,f)
-      nodes.should_not include(e)
+      expect(nodes).to include(a,c,d,f)
+      expect(nodes).not_to include(e)
     end
 
     it "#rels(:friends) should return both incoming and outgoing relationships of given type of depth one" do
@@ -256,10 +256,10 @@ describe Neography::NodeRelationship do
       rels = [*b.rels(:friends)]
 
       # then
-      rels.size.should == 3
+      expect(rels.size).to eq(3)
       nodes = rels.collect{|r| r.end_node}
-      nodes.should include(b,c,f)
-      nodes.should_not include(a,d,e)
+      expect(nodes).to include(b,c,f)
+      expect(nodes).not_to include(a,d,e)
     end
 
     it "#rels(:friends).outgoing should return only outgoing relationships of given type of depth one" do
@@ -270,10 +270,10 @@ describe Neography::NodeRelationship do
       rels = [*b.rels(:friends).outgoing]
 
       # then
-      rels.size.should == 2
+      expect(rels.size).to eq(2)
       nodes = rels.collect{|r| r.end_node}
-      nodes.should include(c,f)
-      nodes.should_not include(a,b,d,e)
+      expect(nodes).to include(c,f)
+      expect(nodes).not_to include(a,b,d,e)
     end
 
 
@@ -285,10 +285,10 @@ describe Neography::NodeRelationship do
       rels = [*b.rels(:friends).incoming]
 
       # then
-      rels.size.should == 1
+      expect(rels.size).to eq(1)
       nodes = rels.collect{|r| r.start_node}
-      nodes.should include(a)
-      nodes.should_not include(b,c,d,e)
+      expect(nodes).to include(a)
+      expect(nodes).not_to include(b,c,d,e)
     end
 
     it "#rels(:friends,:work) should return both incoming and outgoing relationships of given types of depth one" do
@@ -299,10 +299,10 @@ describe Neography::NodeRelationship do
       rels = [*b.rels(:friends,:work)]
 
       # then
-      rels.size.should == 5
+      expect(rels.size).to eq(5)
       nodes = rels.collect{|r| r.other_node(b)}
-      nodes.should include(a,c,d,f)
-      nodes.should_not include(b,e)
+      expect(nodes).to include(a,c,d,f)
+      expect(nodes).not_to include(b,e)
     end
 
     it "#rels(:friends,:work).outgoing should return outgoing relationships of given types of depth one" do
@@ -313,10 +313,10 @@ describe Neography::NodeRelationship do
       rels = [*b.rels(:friends,:work).outgoing]
 
       # then
-      rels.size.should == 4
+      expect(rels.size).to eq(4)
       nodes = rels.collect{|r| r.other_node(b)}
-      nodes.should include(c,d,f)
-      nodes.should_not include(a,b,e)
+      expect(nodes).to include(c,d,f)
+      expect(nodes).not_to include(a,b,e)
     end
   end
 
@@ -325,13 +325,13 @@ describe Neography::NodeRelationship do
       a = Neography::Node.create
       b = Neography::Node.create
       rel = Neography::Relationship.create(:friend, a, b)
-      a.rel(:outgoing, :friend).should == rel
+      expect(a.rel(:outgoing, :friend)).to eq(rel)
     end
 
     it "#rel returns nil if there is no relationship" do
       a = Neography::Node.create
       b = Neography::Node.create
-      a.rel(:outgoing, :friend).should be_empty
+      expect(a.rel(:outgoing, :friend)).to be_empty
     end
 
     it "#rel should only return one relationship even if there are more" do
@@ -347,21 +347,21 @@ describe Neography::NodeRelationship do
   describe "rel?" do
     it "#rel? returns true if there are any relationships" do
       n1 = Neography::Node.create
-      n1.rel?.should be_false
+      expect(n1.rel?).to be_false
       n1.outgoing(:foo) << Neography::Node.create
 
-      n1.rel?.should be_true
-      n1.rel?(:bar).should be_false
-      n1.rel?(:foo).should be_true
-      n1.rel?(:incoming, :foo).should be_false
-      n1.rel?(:outgoing, :foo).should be_true
-      n1.rel?(:foo, :incoming).should be_false
-      n1.rel?(:foo, :outgoing).should be_true
-      n1.rel?(:incoming).should be_false
-      n1.rel?(:outgoing).should be_true
-      n1.rel?(:both).should be_true
-      n1.rel?(:all).should be_true
-      n1.rel?.should be_true
+      expect(n1.rel?).to be_true
+      expect(n1.rel?(:bar)).to be_false
+      expect(n1.rel?(:foo)).to be_true
+      expect(n1.rel?(:incoming, :foo)).to be_false
+      expect(n1.rel?(:outgoing, :foo)).to be_true
+      expect(n1.rel?(:foo, :incoming)).to be_false
+      expect(n1.rel?(:foo, :outgoing)).to be_true
+      expect(n1.rel?(:incoming)).to be_false
+      expect(n1.rel?(:outgoing)).to be_true
+      expect(n1.rel?(:both)).to be_true
+      expect(n1.rel?(:all)).to be_true
+      expect(n1.rel?).to be_true
     end
   end
 

--- a/spec/integration/node_spec.rb
+++ b/spec/integration/node_spec.rb
@@ -5,25 +5,25 @@ describe Neography::Node do
   describe "create and new" do
     it "can create an empty node" do
       new_node = Neography::Node.create
-      new_node.should_not be_nil
+      expect(new_node).not_to be_nil
     end
 
     it "can create a node with one property" do
       new_node = Neography::Node.create("name" => "Max")
-      new_node.name.should == "Max"
+      expect(new_node.name).to eq("Max")
     end
 
     it "can create a node with more than one property" do
       new_node = Neography::Node.create("age" => 31, "name" => "Max")
-      new_node.name.should == "Max"
-      new_node.age.should == 31
+      expect(new_node.name).to eq("Max")
+      expect(new_node.age).to eq(31)
     end
 
     it "can create a node with more than one property not on the default rest server" do
       @neo = Neography::Rest.new
       new_node = Neography::Node.create({"age" => 31, "name" => "Max"}, @neo)
-      new_node.name.should == "Max"
-      new_node.age.should == 31
+      expect(new_node.name).to eq("Max")
+      expect(new_node.age).to eq(31)
     end
 
     it "cannot create a node with more than one property not on the default rest server the other way" do
@@ -39,9 +39,9 @@ describe Neography::Node do
     it "can get a node that exists" do
       new_node = Neography::Node.create
       existing_node = Neography::Node.load(new_node)
-      existing_node.should_not be_nil
-      existing_node.neo_id.should_not be_nil
-      existing_node.neo_id.should == new_node.neo_id
+      expect(existing_node).not_to be_nil
+      expect(existing_node.neo_id).not_to be_nil
+      expect(existing_node.neo_id).to eq(new_node.neo_id)
     end
 
     it "raises an error if it tries to load a node that does not exist" do
@@ -56,9 +56,9 @@ describe Neography::Node do
       @neo = Neography::Rest.new
       new_node = Neography::Node.create({}, @neo)
       existing_node = Neography::Node.load(new_node, @neo)
-      existing_node.should_not be_nil
-      existing_node.neo_id.should_not be_nil
-      existing_node.neo_id.should == new_node.neo_id
+      expect(existing_node).not_to be_nil
+      expect(existing_node.neo_id).not_to be_nil
+      expect(existing_node.neo_id).to eq(new_node.neo_id)
     end
 
     it "cannot load a node that exists not on the default rest server the other way" do
@@ -77,9 +77,9 @@ describe Neography::Node do
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       node_from_index = @neo.get_node_index("test_node_index", key, value) 
       existing_node = Neography::Node.load(node_from_index)
-      existing_node.should_not be_nil
-      existing_node.neo_id.should_not be_nil
-      existing_node.neo_id.should == new_node.neo_id
+      expect(existing_node).not_to be_nil
+      expect(existing_node.neo_id).not_to be_nil
+      expect(existing_node.neo_id).to eq(new_node.neo_id)
     end
 
     it "can get a node that exists via cypher" do
@@ -88,9 +88,9 @@ describe Neography::Node do
       @neo = Neography::Rest.new
       results = @neo.execute_query(cypher, {:id => new_node.neo_id.to_i})
       existing_node = Neography::Node.load(results)
-      existing_node.should_not be_nil
-      existing_node.neo_id.should_not be_nil
-      existing_node.neo_id.should == new_node.neo_id
+      expect(existing_node).not_to be_nil
+      expect(existing_node.neo_id).not_to be_nil
+      expect(existing_node.neo_id).to eq(new_node.neo_id)
     end
 
 
@@ -110,13 +110,13 @@ describe Neography::Node do
   describe "exists?" do
     it "can tell if it exists" do
       new_node = Neography::Node.create
-      new_node.exist?.should be_true
+      expect(new_node.exist?).to be_true
     end
 
     it "can tell if does not exists" do
       new_node = Neography::Node.create
       new_node.del
-      new_node.exist?.should be_false
+      expect(new_node.exist?).to be_false
     end
   end
 
@@ -124,19 +124,19 @@ describe Neography::Node do
     it "can tell two nodes are the same with equal?" do
       new_node = Neography::Node.create
       another_node = Neography::Node.load(new_node)
-      new_node.equal?(another_node).should be_true 
+      expect(new_node.equal?(another_node)).to be_true 
     end
 
     it "can tell two nodes are the same with eql?" do
       new_node = Neography::Node.create
       another_node = Neography::Node.load(new_node)
-      new_node.eql?(another_node).should be_true 
+      expect(new_node.eql?(another_node)).to be_true 
     end
 
     it "can tell two nodes are the same with ==" do
       new_node = Neography::Node.create
       another_node = Neography::Node.load(new_node)
-      (new_node == another_node).should be_true 
+      expect(new_node == another_node).to be_true 
     end
   end
 
@@ -148,8 +148,8 @@ describe Neography::Node do
       new_node[:eyes] = "brown"
 
       existing_node = Neography::Node.load(new_node)
-      existing_node.weight.should == 200
-      existing_node.eyes.should == "brown"
+      expect(existing_node.weight).to eq(200)
+      expect(existing_node.eyes).to eq("brown")
     end
 
     it "can change a node's properties that already exist" do
@@ -159,8 +159,8 @@ describe Neography::Node do
       new_node.eyes = "brown"
 
       existing_node = Neography::Node.load(new_node)
-      existing_node.weight.should == 200
-      existing_node.eyes.should == "brown"
+      expect(existing_node.weight).to eq(200)
+      expect(existing_node.eyes).to eq("brown")
     end
 
     it "can change a node's properties that does not already exist using []=" do
@@ -171,9 +171,9 @@ describe Neography::Node do
       new_node[:hair] = "black"
 
       existing_node = Neography::Node.load(new_node)
-      existing_node.weight.should == 200
-      existing_node.eyes.should == "brown"
-      existing_node.hair.should == "black"
+      expect(existing_node.weight).to eq(200)
+      expect(existing_node.eyes).to eq("brown")
+      expect(existing_node.hair).to eq("black")
     end
 
     it "can change a node's properties that does not already exist" do
@@ -182,23 +182,23 @@ describe Neography::Node do
       new_node.hair = "black"
 
       existing_node = Neography::Node.load(new_node)
-      existing_node.hair.should == "black"
+      expect(existing_node.hair).to eq("black")
     end
 
     it "can pass issue 18" do
       n = Neography::Node.create("name" => "Test")
       n.prop = 1
-      n.prop.should == 1           
+      expect(n.prop).to eq(1)           
       n.prop = 1                   
-      n.prop.should == 1           
-      n[:prop].should == 1         
+      expect(n.prop).to eq(1)           
+      expect(n[:prop]).to eq(1)         
       n[:prop2] = 2                  
-      n[:prop2].should == 2          
+      expect(n[:prop2]).to eq(2)          
       n[:prop2] = 2                  
-      n[:prop2].should == 2          
+      expect(n[:prop2]).to eq(2)          
       n.name                         
       n.name = "New Name"            
-      n.name.should == "New Name"
+      expect(n.name).to eq("New Name")
     end
 
   end
@@ -206,14 +206,14 @@ describe Neography::Node do
   describe "get node properties" do
     it "can get node properties using []" do
       new_node = Neography::Node.create("weight" => 150, "eyes" => "green")
-      new_node[:weight].should == 150
-      new_node[:eyes].should == "green"
+      expect(new_node[:weight]).to eq(150)
+      expect(new_node[:eyes]).to eq("green")
     end
 
     it "can get node properties" do
       new_node = Neography::Node.create("weight" => 150, "eyes" => "green")
-      new_node.weight.should == 150
-      new_node.eyes.should == "green"
+      expect(new_node.weight).to eq(150)
+      expect(new_node.eyes).to eq("green")
     end
   end
 
@@ -224,12 +224,12 @@ describe Neography::Node do
       new_node[:weight] = nil
       new_node[:eyes] = nil
 
-      new_node[:weight].should be_nil
-      new_node[:eyes].should be_nil
+      expect(new_node[:weight]).to be_nil
+      expect(new_node[:eyes]).to be_nil
 
       existing_node = Neography::Node.load(new_node)
-      existing_node.weight.should be_nil
-      existing_node.eyes.should be_nil
+      expect(existing_node.weight).to be_nil
+      expect(existing_node.eyes).to be_nil
     end
 
     it "can delete node properties" do
@@ -238,12 +238,12 @@ describe Neography::Node do
       new_node.weight = nil
       new_node.eyes = nil
 
-      new_node.weight.should be_nil
-      new_node.eyes.should be_nil
+      expect(new_node.weight).to be_nil
+      expect(new_node.eyes).to be_nil
 
       existing_node = Neography::Node.load(new_node)
-      existing_node.weight.should be_nil
-      existing_node.eyes.should be_nil
+      expect(existing_node.weight).to be_nil
+      expect(existing_node.eyes).to be_nil
     end
   end
 
@@ -255,6 +255,6 @@ describe Neography::Node do
       node
     }
 
-    it { subject.labels.should == %w(Label Label2) }
+    it { expect(subject.labels).to eq(%w(Label Label2)) }
   end
 end

--- a/spec/integration/parsing_spec.rb
+++ b/spec/integration/parsing_spec.rb
@@ -6,8 +6,8 @@ describe Neography do
     it 'should not convert strings to symbol' do
       node = subject.create_node({:text => ':1456'})
 
-      node['data']['text'].class.should == String # fails! expected: String got: Symbol (using ==)
-      node['data']['text'].should == ':1456'
+      expect(node['data']['text'].class).to eq(String) # fails! expected: String got: Symbol (using ==)
+      expect(node['data']['text']).to eq(':1456')
     end
   end
 end

--- a/spec/integration/relationship_spec.rb
+++ b/spec/integration/relationship_spec.rb
@@ -7,8 +7,8 @@ describe Neography::Relationship do
       p2 = Neography::Node.create
 
       Neography::Relationship.create(:family, p1, p2)
-      p1.outgoing(:family).should include(p2)
-      p2.incoming(:family).should include(p1)
+      expect(p1.outgoing(:family)).to include(p2)
+      expect(p2.incoming(:family)).to include(p1)
     end
 
     it "#new(:family, p1, p2, :since => '1998', :colour => 'blue') creates relationship and sets its properties" do
@@ -16,10 +16,10 @@ describe Neography::Relationship do
       p2 = Neography::Node.create
       rel = Neography::Relationship.create(:family, p1, p2, :since => 1998, :colour => 'blue')
 
-      rel[:since].should == 1998
-      rel[:colour].should == 'blue'
-      rel.since.should == 1998
-      rel.colour.should == 'blue'
+      expect(rel[:since]).to eq(1998)
+      expect(rel[:colour]).to eq('blue')
+      expect(rel.since).to eq(1998)
+      expect(rel.colour).to eq('blue')
     end
 
     it "#outgoing(:friends).create(other) creates a new relationship between self and other node" do
@@ -27,10 +27,10 @@ describe Neography::Relationship do
       p2 = Neography::Node.create
       rel = p1.outgoing(:foo).create(p2)
 
-      rel.should be_kind_of(Neography::Relationship)
-      p1.outgoing(:foo).first.should == p2
-      p1.outgoing(:foo).should include(p2)
-      p2.incoming(:foo).should include(p1)
+      expect(rel).to be_kind_of(Neography::Relationship)
+      expect(p1.outgoing(:foo).first).to eq(p2)
+      expect(p1.outgoing(:foo)).to include(p2)
+      expect(p2.incoming(:foo)).to include(p1)
     end
   end
 

--- a/spec/integration/rest_batch_no_streaming_spec.rb
+++ b/spec/integration/rest_batch_no_streaming_spec.rb
@@ -13,8 +13,8 @@ describe Neography::Rest do
         commands << [:create_node, {"name" => "Max " + x.to_s}]
       end
       batch_result = @neo.batch_no_streaming *commands
-      batch_result.first["body"]["data"]["name"].should == "Max 0"
-      batch_result.last["body"]["data"]["name"].should == "Max 999"
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max 0")
+      expect(batch_result.last["body"]["data"]["name"]).to eq("Max 999")
     end
 
     it "can send a 5000 item batch" do
@@ -23,8 +23,8 @@ describe Neography::Rest do
         commands << [:get_node, 0]
       end
       batch_result = @neo.batch_no_streaming *commands
-      batch_result.first["body"]["self"].split('/').last.should == "0"
-      batch_result.last["body"]["self"].split('/').last.should == "0"
+      expect(batch_result.first["body"]["self"].split('/').last).to eq("0")
+      expect(batch_result.last["body"]["self"].split('/').last).to eq("0")
     end
 
     it "can send a 20000 item batch" do
@@ -33,8 +33,8 @@ describe Neography::Rest do
         commands << [:create_node, {"name" => "Max " + x.to_s}]
       end
       batch_result = @neo.batch_no_streaming *commands
-      batch_result.first["body"]["data"]["name"].should == "Max 0"
-      batch_result.last["body"]["data"]["name"].should == "Max 19999"
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max 0")
+      expect(batch_result.last["body"]["data"]["name"]).to eq("Max 19999")
     end
   end
 

--- a/spec/integration/rest_batch_spec.rb
+++ b/spec/integration/rest_batch_spec.rb
@@ -10,11 +10,11 @@ describe Neography::Rest do
       new_node = @neo.create_node
       new_node[:id] = new_node["self"].split('/').last
       batch_result = @neo.batch [:get_node, new_node]
-      batch_result.first.should_not be_nil
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("body")
-      batch_result.first.should have_key("from")
-      batch_result.first["body"]["self"].split('/').last.should == new_node[:id]
+      expect(batch_result.first).not_to be_nil
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("body")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.first["body"]["self"].split('/').last).to eq(new_node[:id])
     end
 
     it "can get multiple nodes" do
@@ -24,33 +24,33 @@ describe Neography::Rest do
       node2[:id] = node2["self"].split('/').last
 
       batch_result = @neo.batch [:get_node, node1], [:get_node, node2]
-      batch_result.first.should_not be_nil
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("body")
-      batch_result.first.should have_key("from")
-      batch_result.first["body"]["self"].split('/').last.should == node1[:id]
-      batch_result.last.should have_key("id")
-      batch_result.last.should have_key("body")
-      batch_result.last.should have_key("from")
-      batch_result.last["body"]["self"].split('/').last.should == node2[:id]
+      expect(batch_result.first).not_to be_nil
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("body")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.first["body"]["self"].split('/').last).to eq(node1[:id])
+      expect(batch_result.last).to have_key("id")
+      expect(batch_result.last).to have_key("body")
+      expect(batch_result.last).to have_key("from")
+      expect(batch_result.last["body"]["self"].split('/').last).to eq(node2[:id])
 
     end
 
     it "can create a single node" do
       batch_result = @neo.batch [:create_node, {"name" => "Max"}]
-      batch_result.first["body"]["data"]["name"].should == "Max"
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max")
     end
 
     it "can create multiple nodes" do
       batch_result = @neo.batch [:create_node, {"name" => "Max"}], [:create_node, {"name" => "Marc"}]
-      batch_result.first["body"]["data"]["name"].should == "Max"
-      batch_result.last["body"]["data"]["name"].should == "Marc"
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max")
+      expect(batch_result.last["body"]["data"]["name"]).to eq("Marc")
     end
 
     it "can create multiple nodes given an *array" do
       batch_result = @neo.batch *[[:create_node, {"name" => "Max"}], [:create_node, {"name" => "Marc"}]]
-      batch_result.first["body"]["data"]["name"].should == "Max"
-      batch_result.last["body"]["data"]["name"].should == "Marc"
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max")
+      expect(batch_result.last["body"]["data"]["name"]).to eq("Marc")
     end
 
     it "can create a unique node" do
@@ -59,94 +59,94 @@ describe Neography::Rest do
       value = generate_text
       @neo.create_node_index(index_name)
       batch_result = @neo.batch [:create_unique_node, index_name, key, value, {"age" => 31, "name" => "Max"}]
-      batch_result.first["body"]["data"]["name"].should == "Max"
-      batch_result.first["body"]["data"]["age"].should == 31
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max")
+      expect(batch_result.first["body"]["data"]["age"]).to eq(31)
       new_node_id = batch_result.first["body"]["self"].split('/').last
       batch_result = @neo.batch [:create_unique_node, index_name, key, value, {"age" => 31, "name" => "Max"}]
-      batch_result.first["body"]["self"].split('/').last.should == new_node_id
-      batch_result.first["body"]["data"]["name"].should == "Max"
-      batch_result.first["body"]["data"]["age"].should == 31
+      expect(batch_result.first["body"]["self"].split('/').last).to eq(new_node_id)
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max")
+      expect(batch_result.first["body"]["data"]["age"]).to eq(31)
 
       #Sanity Check
       existing_node = @neo.create_unique_node(index_name, key, value, {"age" => 31, "name" => "Max"})
-      existing_node["self"].split('/').last.should == new_node_id
-      existing_node["data"]["name"].should == "Max"
-      existing_node["data"]["age"].should == 31
+      expect(existing_node["self"].split('/').last).to eq(new_node_id)
+      expect(existing_node["data"]["name"]).to eq("Max")
+      expect(existing_node["data"]["age"]).to eq(31)
     end
 
     it "can update a property of a node" do
       new_node = @neo.create_node("name" => "Max")
       batch_result = @neo.batch [:set_node_property, new_node, {"name" => "Marc"}]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
       existing_node = @neo.get_node(new_node)
-      existing_node["data"]["name"].should == "Marc"
+      expect(existing_node["data"]["name"]).to eq("Marc")
     end
 
     it "can update a property of multiple nodes" do
       node1 = @neo.create_node("name" => "Max")
       node2 = @neo.create_node("name" => "Marc")
       batch_result = @neo.batch [:set_node_property, node1, {"name" => "Tom"}], [:set_node_property, node2, {"name" => "Jerry"}]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
-      batch_result.last.should have_key("id")
-      batch_result.last.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.last).to have_key("id")
+      expect(batch_result.last).to have_key("from")
       existing_node = @neo.get_node(node1)
-      existing_node["data"]["name"].should == "Tom"
+      expect(existing_node["data"]["name"]).to eq("Tom")
       existing_node = @neo.get_node(node2)
-      existing_node["data"]["name"].should == "Jerry"
+      expect(existing_node["data"]["name"]).to eq("Jerry")
     end
 
     it "can reset the properties of a node" do
       new_node = @neo.create_node("name" => "Max", "weight" => 200)
       batch_result = @neo.batch [:reset_node_properties, new_node, {"name" => "Marc"}]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
       existing_node = @neo.get_node(new_node)
-      existing_node["data"]["name"].should == "Marc"
-      existing_node["data"]["weight"].should be_nil
+      expect(existing_node["data"]["name"]).to eq("Marc")
+      expect(existing_node["data"]["weight"]).to be_nil
     end
 
     it "can reset the properties of multiple nodes" do
       node1 = @neo.create_node("name" => "Max", "weight" => 200)
       node2 = @neo.create_node("name" => "Marc", "weight" => 180)
       batch_result = @neo.batch [:reset_node_properties, node1, {"name" => "Tom"}], [:reset_node_properties, node2, {"name" => "Jerry"}]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
-      batch_result.last.should have_key("id")
-      batch_result.last.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.last).to have_key("id")
+      expect(batch_result.last).to have_key("from")
       existing_node = @neo.get_node(node1)
-      existing_node["data"]["name"].should == "Tom"
-      existing_node["data"]["weight"].should be_nil
+      expect(existing_node["data"]["name"]).to eq("Tom")
+      expect(existing_node["data"]["weight"]).to be_nil
       existing_node = @neo.get_node(node2)
-      existing_node["data"]["name"].should == "Jerry"
-      existing_node["data"]["weight"].should be_nil
+      expect(existing_node["data"]["name"]).to eq("Jerry")
+      expect(existing_node["data"]["weight"]).to be_nil
     end
 
     it "can remove a property of a node" do
       new_node = @neo.create_node("name" => "Max", "weight" => 200)
       batch_result = @neo.batch [:remove_node_property, new_node, "weight"]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
       existing_node = @neo.get_node(new_node)
-      existing_node["data"]["name"].should == "Max"
-      existing_node["data"]["weight"].should be_nil
+      expect(existing_node["data"]["name"]).to eq("Max")
+      expect(existing_node["data"]["weight"]).to be_nil
     end
 
     it "can remove a property of multiple nodes" do
       node1 = @neo.create_node("name" => "Max", "weight" => 200)
       node2 = @neo.create_node("name" => "Marc", "weight" => 180)
       batch_result = @neo.batch [:remove_node_property, node1, "name"], [:remove_node_property, node2, "name"]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
-      batch_result.last.should have_key("id")
-      batch_result.last.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.last).to have_key("id")
+      expect(batch_result.last).to have_key("from")
       existing_node = @neo.get_node(node1)
-      existing_node["data"]["name"].should be_nil
-      existing_node["data"]["weight"].should == 200
+      expect(existing_node["data"]["name"]).to be_nil
+      expect(existing_node["data"]["weight"]).to eq(200)
       existing_node = @neo.get_node(node2)
-      existing_node["data"]["name"].should be_nil
-      existing_node["data"]["weight"].should == 180
+      expect(existing_node["data"]["name"]).to be_nil
+      expect(existing_node["data"]["weight"]).to eq(180)
     end
 
     it "can get a single relationship" do
@@ -154,42 +154,42 @@ describe Neography::Rest do
       node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", node1, node2)
       batch_result = @neo.batch [:get_relationship, new_relationship]
-      batch_result.first["body"]["type"].should == "friends"
-      batch_result.first["body"]["start"].split('/').last.should == node1["self"].split('/').last
-      batch_result.first["body"]["end"].split('/').last.should == node2["self"].split('/').last
-      batch_result.first["body"]["self"].should == new_relationship["self"]
+      expect(batch_result.first["body"]["type"]).to eq("friends")
+      expect(batch_result.first["body"]["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(batch_result.first["body"]["end"].split('/').last).to eq(node2["self"].split('/').last)
+      expect(batch_result.first["body"]["self"]).to eq(new_relationship["self"])
     end
 
     it "can create a single relationship without properties" do
       node1 = @neo.create_node
       node2 = @neo.create_node
       batch_result = @neo.batch [:create_relationship, "friends", node1, node2]
-      batch_result.first["body"]["type"].should == "friends"
-      batch_result.first["body"]["data"]["since"].should be_nil
-      batch_result.first["body"]["start"].split('/').last.should == node1["self"].split('/').last
-      batch_result.first["body"]["end"].split('/').last.should == node2["self"].split('/').last
+      expect(batch_result.first["body"]["type"]).to eq("friends")
+      expect(batch_result.first["body"]["data"]["since"]).to be_nil
+      expect(batch_result.first["body"]["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(batch_result.first["body"]["end"].split('/').last).to eq(node2["self"].split('/').last)
     end
 
     it "can create a single relationship" do
       node1 = @neo.create_node
       node2 = @neo.create_node
       batch_result = @neo.batch [:create_relationship, "friends", node1, node2, {:since => "high school"}]
-      batch_result.first["body"]["type"].should == "friends"
-      batch_result.first["body"]["data"]["since"].should == "high school"
-      batch_result.first["body"]["start"].split('/').last.should == node1["self"].split('/').last
-      batch_result.first["body"]["end"].split('/').last.should == node2["self"].split('/').last
+      expect(batch_result.first["body"]["type"]).to eq("friends")
+      expect(batch_result.first["body"]["data"]["since"]).to eq("high school")
+      expect(batch_result.first["body"]["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(batch_result.first["body"]["end"].split('/').last).to eq(node2["self"].split('/').last)
     end
 
     it "can delete a single relationship" do
       node1 = @neo.create_node
       node2 = @neo.create_node
       batch_result = @neo.batch [:create_relationship, "friends", node1, node2, {:since => "time immemorial"}]
-      batch_result.should_not be_nil
-      batch_result[0]["status"].should == 201
+      expect(batch_result).not_to be_nil
+      expect(batch_result[0]["status"]).to eq(201)
       id = batch_result.first["body"]["self"].split("/").last
       batch_result = @neo.batch [:delete_relationship, id]
-      batch_result[0]["status"].should == 204
-      batch_result[0]["from"].should == "/relationship/#{id}"
+      expect(batch_result[0]["status"]).to eq(204)
+      expect(batch_result[0]["from"]).to eq("/relationship/#{id}")
     end
 
     it "can create a unique relationship" do
@@ -200,9 +200,9 @@ describe Neography::Rest do
       node1 = @neo.create_node
       node2 = @neo.create_node
       batch_result = @neo.batch [:create_unique_relationship, index_name, key, value, "friends", node1, node2]
-      batch_result.first["body"]["type"].should == "friends"
-      batch_result.first["body"]["start"].split('/').last.should == node1["self"].split('/').last
-      batch_result.first["body"]["end"].split('/').last.should == node2["self"].split('/').last
+      expect(batch_result.first["body"]["type"]).to eq("friends")
+      expect(batch_result.first["body"]["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(batch_result.first["body"]["end"].split('/').last).to eq(node2["self"].split('/').last)
     end
 
     it "can update a single relationship" do
@@ -210,14 +210,14 @@ describe Neography::Rest do
       node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", node1, node2, {:since => "high school"})
       batch_result = @neo.batch [:set_relationship_property, new_relationship, {:since => "college"}]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
       existing_relationship = @neo.get_relationship(new_relationship)
-      existing_relationship["type"].should == "friends"
-      existing_relationship["data"]["since"].should == "college"
-      existing_relationship["start"].split('/').last.should == node1["self"].split('/').last
-      existing_relationship["end"].split('/').last.should == node2["self"].split('/').last
-      existing_relationship["self"].should == new_relationship["self"]
+      expect(existing_relationship["type"]).to eq("friends")
+      expect(existing_relationship["data"]["since"]).to eq("college")
+      expect(existing_relationship["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(existing_relationship["end"].split('/').last).to eq(node2["self"].split('/').last)
+      expect(existing_relationship["self"]).to eq(new_relationship["self"])
     end
 
     it "can reset the properties of a relationship" do
@@ -225,22 +225,22 @@ describe Neography::Rest do
       node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", node1, node2, {:since => "high school"})
       batch_result = @neo.batch [:reset_relationship_properties, new_relationship, {"since" => "college", "dated" => "yes"}]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
       existing_relationship = @neo.get_relationship(batch_result.first["from"].split('/')[2])
-      existing_relationship["type"].should == "friends"
-      existing_relationship["data"]["since"].should == "college"
-      existing_relationship["data"]["dated"].should == "yes"
-      existing_relationship["start"].split('/').last.should == node1["self"].split('/').last
-      existing_relationship["end"].split('/').last.should == node2["self"].split('/').last
-      existing_relationship["self"].should == new_relationship["self"]
+      expect(existing_relationship["type"]).to eq("friends")
+      expect(existing_relationship["data"]["since"]).to eq("college")
+      expect(existing_relationship["data"]["dated"]).to eq("yes")
+      expect(existing_relationship["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(existing_relationship["end"].split('/').last).to eq(node2["self"].split('/').last)
+      expect(existing_relationship["self"]).to eq(new_relationship["self"])
     end
 
     it "can drop a node index" do
       index_name = generate_text(6)
       @neo.create_node_index(index_name)
       @neo.batch [:drop_node_index, index_name]
-      @neo.list_node_indexes[index_name].should be_nil
+      expect(@neo.list_node_indexes[index_name]).to be_nil
     end
 
     it "can create a node index" do
@@ -248,9 +248,9 @@ describe Neography::Rest do
       @neo.batch [:create_node_index, index_name, "fulltext", "lucene"]
       indexes = @neo.list_node_indexes
       index = indexes[index_name]
-      index.should_not be_nil
-      index["provider"].should == "lucene"
-      index["type"].should == "fulltext"
+      expect(index).not_to be_nil
+      expect(index["provider"]).to eq("lucene")
+      expect(index["type"]).to eq("fulltext")
     end
 
     it "can add a node to an index" do
@@ -259,11 +259,11 @@ describe Neography::Rest do
       key = generate_text(6)
       value = generate_text
       batch_result = @neo.batch [:add_node_to_index, index_name, key, value, new_node]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
       existing_index = @neo.find_node_index(index_name, key, value)
-      existing_index.should_not be_nil
-      existing_index.first["self"].should == new_node["self"]
+      expect(existing_index).not_to be_nil
+      expect(existing_index.first["self"]).to eq(new_node["self"])
       @neo.remove_node_from_index(index_name, key, value, new_node)
     end
 
@@ -275,9 +275,9 @@ describe Neography::Rest do
       new_node = @neo.create_node
       @neo.add_node_to_index(index_name, key, value, new_node)
       batch_result = @neo.batch [:get_node_index, index_name, key, value]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
-      batch_result.first["body"].first["self"].should == new_node["self"]
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.first["body"].first["self"]).to eq(new_node["self"])
       @neo.remove_node_from_index(index_name, key, value, new_node)
     end
 
@@ -291,43 +291,43 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", node1, node2, {:since => "high school"})
       @neo.add_relationship_to_index(index_name, key, value, new_relationship)
       batch_result = @neo.batch [:get_relationship_index, index_name, key, value]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
-      batch_result.first["body"].first["type"].should == "friends"
-      batch_result.first["body"].first["start"].split('/').last.should == node1["self"].split('/').last
-      batch_result.first["body"].first["end"].split('/').last.should == node2["self"].split('/').last
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.first["body"].first["type"]).to eq("friends")
+      expect(batch_result.first["body"].first["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(batch_result.first["body"].first["end"].split('/').last).to eq(node2["self"].split('/').last)
     end
 
     it "can batch gremlin", :gremlin => true  do
       batch_result = @neo.batch [:execute_script, "g.v(0)"]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
-      batch_result.first["body"]["self"].split('/').last.should == "0"
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.first["body"]["self"].split('/').last).to eq("0")
     end
 
     it "can batch gremlin with parameters", :gremlin => true  do
       new_node = @neo.create_node
       id = new_node["self"].split('/').last
       batch_result = @neo.batch [:execute_script, "g.v(id)", {:id => id.to_i}]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
-      batch_result.first["body"]["self"].split('/').last.should == id
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.first["body"]["self"].split('/').last).to eq(id)
     end
 
     it "can batch cypher" do
       batch_result = @neo.batch [:execute_query, "start n=node(0) return n"]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
-      batch_result.first["body"]["data"][0][0]["self"].split('/').last.should == "0"
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.first["body"]["data"][0][0]["self"].split('/').last).to eq("0")
     end
 
     it "can batch cypher with parameters" do
       new_node = @neo.create_node
       id = new_node["self"].split('/').last
       batch_result = @neo.batch [:execute_query, "start n=node({id}) return n", {:id => id.to_i}]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
-      batch_result.first["body"]["data"][0][0]["self"].split('/').last.should == id
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
+      expect(batch_result.first["body"]["data"][0][0]["self"].split('/').last).to eq(id)
     end
 
     it "raises ParameterNotFoundException when a cypher parameter is missing and ORDER BY is used" do
@@ -344,10 +344,10 @@ describe Neography::Rest do
   		id2 = node2['self'].split('/').last
   		batch_result = @neo.batch [:delete_node, id1 ], [:delete_node, id2]
       expect {
-        @neo.get_node(node1).should be_nil
+        expect(@neo.get_node(node1)).to be_nil
       }.to raise_error Neography::NodeNotFoundException
       expect {
-        @neo.get_node(node2).should be_nil
+        expect(@neo.get_node(node2)).to be_nil
       }.to raise_error Neography::NodeNotFoundException
   	end
 
@@ -366,9 +366,9 @@ describe Neography::Rest do
   		                          [:remove_node_from_index, index, key, node2 ],
   		                          [:remove_node_from_index, index, node3 ]
 
-  		@neo.get_node_index(index, key, value1).should be_nil
-  		@neo.get_node_index(index, key, value2).should be_nil
-  		@neo.get_node_index(index, key, value3).should be_nil
+  		expect(@neo.get_node_index(index, key, value1)).to be_nil
+  		expect(@neo.get_node_index(index, key, value2)).to be_nil
+  		expect(@neo.get_node_index(index, key, value3)).to be_nil
   	end
 
     it "can remove a relationship from an index in batch" do
@@ -385,8 +385,8 @@ describe Neography::Rest do
        batch_result = @neo.batch [:remove_relationship_from_index, index, key, relationship1],
          [:remove_relationship_from_index, index, key, relationship2]
 
-       @neo.get_relationship_index(index, key, value1).should be_nil
-       @neo.get_relationship_index(index, key, value2).should be_nil
+       expect(@neo.get_relationship_index(index, key, value1)).to be_nil
+       expect(@neo.get_relationship_index(index, key, value2)).to be_nil
      end
     
     it "can do spatial via Cypher in batch" do
@@ -397,47 +397,47 @@ describe Neography::Rest do
                                 [:execute_query, "start n = node:geobatchcypher({withinDistance}) return n", {:withinDistance => "withinDistance:[60.0,15.0,100.0]"}],
                                 [:execute_query, "start n = node:geobatchcypher({bbox}) return n", {:bbox => "bbox:[15.0,15.3,60.0,60.2]"}]
 
-      batch_result[0]["body"]["provider"].should == "spatial"
-      batch_result[0]["body"]["geometry_type"].should == "point"
-      batch_result[0]["body"]["lat"].should == "lat"
-      batch_result[0]["body"]["lon"].should == "lon"
-      batch_result[1]["from"].should == "/index/node/geobatchcypher"
-      batch_result[1]["body"]["data"].should == {"lat" => 60.1, "lon" => 15.2}
-      batch_result[2]["body"]["data"].should_not be_empty
-      batch_result[3]["body"]["data"].should_not be_empty
+      expect(batch_result[0]["body"]["provider"]).to eq("spatial")
+      expect(batch_result[0]["body"]["geometry_type"]).to eq("point")
+      expect(batch_result[0]["body"]["lat"]).to eq("lat")
+      expect(batch_result[0]["body"]["lon"]).to eq("lon")
+      expect(batch_result[1]["from"]).to eq("/index/node/geobatchcypher")
+      expect(batch_result[1]["body"]["data"]).to eq({"lat" => 60.1, "lon" => 15.2})
+      expect(batch_result[2]["body"]["data"]).not_to be_empty
+      expect(batch_result[3]["body"]["data"]).not_to be_empty
     end
   end
 
   describe "referenced batch" do
     it "can create a relationship from two newly created nodes" do
       batch_result = @neo.batch [:create_node, {"name" => "Max"}], [:create_node, {"name" => "Marc"}], [:create_relationship, "friends", "{0}", "{1}", {:since => "high school"}]
-      batch_result.first["body"]["data"]["name"].should == "Max"
-      batch_result[1]["body"]["data"]["name"].should == "Marc"
-      batch_result.last["body"]["type"].should == "friends"
-      batch_result.last["body"]["data"]["since"].should == "high school"
-      batch_result.last["body"]["start"].split('/').last.should == batch_result.first["body"]["self"].split('/').last
-      batch_result.last["body"]["end"].split('/').last.should == batch_result[1]["body"]["self"].split('/').last
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max")
+      expect(batch_result[1]["body"]["data"]["name"]).to eq("Marc")
+      expect(batch_result.last["body"]["type"]).to eq("friends")
+      expect(batch_result.last["body"]["data"]["since"]).to eq("high school")
+      expect(batch_result.last["body"]["start"].split('/').last).to eq(batch_result.first["body"]["self"].split('/').last)
+      expect(batch_result.last["body"]["end"].split('/').last).to eq(batch_result[1]["body"]["self"].split('/').last)
     end
 
     it "can create a relationship from an existing node and a newly created node" do
       node1 = @neo.create_node("name" => "Max", "weight" => 200)
       batch_result = @neo.batch [:create_node, {"name" => "Marc"}], [:create_relationship, "friends", "{0}", node1, {:since => "high school"}]
-      batch_result.first["body"]["data"]["name"].should == "Marc"
-      batch_result.last["body"]["type"].should == "friends"
-      batch_result.last["body"]["data"]["since"].should == "high school"
-      batch_result.last["body"]["start"].split('/').last.should == batch_result.first["body"]["self"].split('/').last
-      batch_result.last["body"]["end"].split('/').last.should == node1["self"].split('/').last
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Marc")
+      expect(batch_result.last["body"]["type"]).to eq("friends")
+      expect(batch_result.last["body"]["data"]["since"]).to eq("high school")
+      expect(batch_result.last["body"]["start"].split('/').last).to eq(batch_result.first["body"]["self"].split('/').last)
+      expect(batch_result.last["body"]["end"].split('/').last).to eq(node1["self"].split('/').last)
     end
 
     it "can add a newly created node to an index" do
       key = generate_text(6)
       value = generate_text
       batch_result = @neo.batch [:create_node, {"name" => "Max"}], [:add_node_to_index, "test_node_index", key, value, "{0}"]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
       existing_index = @neo.find_node_index("test_node_index", key, value)
-      existing_index.should_not be_nil
-      existing_index.first["self"].should == batch_result.first["body"]["self"]
+      expect(existing_index).not_to be_nil
+      expect(existing_index.first["self"]).to eq(batch_result.first["body"]["self"])
       @neo.remove_node_from_index("test_node_index", key, value, batch_result.first["body"]["self"].split('/').last)
     end
 
@@ -447,28 +447,28 @@ describe Neography::Rest do
       node1 = @neo.create_node
       node2 = @neo.create_node
       batch_result = @neo.batch [:create_relationship, "friends", node1, node2, {:since => "high school"}], [:add_relationship_to_index, "test_relationship_index", key, value, "{0}"]
-      batch_result.first["body"]["type"].should == "friends"
-      batch_result.first["body"]["data"]["since"].should == "high school"
-      batch_result.first["body"]["start"].split('/').last.should == node1["self"].split('/').last
-      batch_result.first["body"]["end"].split('/').last.should == node2["self"].split('/').last
+      expect(batch_result.first["body"]["type"]).to eq("friends")
+      expect(batch_result.first["body"]["data"]["since"]).to eq("high school")
+      expect(batch_result.first["body"]["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(batch_result.first["body"]["end"].split('/').last).to eq(node2["self"].split('/').last)
       existing_index = @neo.find_relationship_index("test_relationship_index", key, value)
-      existing_index.should_not be_nil
-      existing_index.first["self"].should == batch_result.first["body"]["self"]
+      expect(existing_index).not_to be_nil
+      expect(existing_index.first["self"]).to eq(batch_result.first["body"]["self"])
     end
 
     it "can reset the properties of a newly created relationship" do
       node1 = @neo.create_node
       node2 = @neo.create_node
       batch_result = @neo.batch [:create_relationship, "friends", node1, node2, {:since => "high school"}], [:reset_relationship_properties, "{0}", {"since" => "college", "dated" => "yes"}]
-      batch_result.first.should have_key("id")
-      batch_result.first.should have_key("from")
+      expect(batch_result.first).to have_key("id")
+      expect(batch_result.first).to have_key("from")
       existing_relationship = @neo.get_relationship(batch_result.first["body"]["self"].split('/').last)
-      existing_relationship["type"].should == "friends"
-      existing_relationship["data"]["since"].should == "college"
-      existing_relationship["data"]["dated"].should == "yes"
-      existing_relationship["start"].split('/').last.should == node1["self"].split('/').last
-      existing_relationship["end"].split('/').last.should == node2["self"].split('/').last
-      existing_relationship["self"].should == batch_result.first["body"]["self"]
+      expect(existing_relationship["type"]).to eq("friends")
+      expect(existing_relationship["data"]["since"]).to eq("college")
+      expect(existing_relationship["data"]["dated"]).to eq("yes")
+      expect(existing_relationship["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(existing_relationship["end"].split('/').last).to eq(node2["self"].split('/').last)
+      expect(existing_relationship["self"]).to eq(batch_result.first["body"]["self"])
     end
 
     it "can kitchen sink" do
@@ -481,7 +481,7 @@ describe Neography::Rest do
                                 [:add_node_to_index, "test_node_index", key, value, "{1}"]
                                 [:create_relationship, "friends", "{0}", "{1}", {:since => "college"}]
                                 [:add_relationship_to_index, "test_relationship_index", key, value, "{4}"]
-      batch_result.should_not be_nil
+      expect(batch_result).not_to be_nil
     end
 
     it "can get multiple relationships" do
@@ -491,15 +491,15 @@ describe Neography::Rest do
       new_relationship1 = @neo.create_relationship("friends", node1, node2)
       new_relationship2 = @neo.create_relationship("brothers", node1, node3)
       batch_result = @neo.batch [:get_node_relationships, node1]
-      batch_result.first["body"].length.should be(2)
-      batch_result.first["body"][0]["type"].should == "friends"
-      batch_result.first["body"][0]["start"].split('/').last.should == node1["self"].split('/').last
-      batch_result.first["body"][0]["end"].split('/').last.should == node2["self"].split('/').last
-      batch_result.first["body"][0]["self"].should == new_relationship1["self"]
-      batch_result.first["body"][1]["type"].should == "brothers"
-      batch_result.first["body"][1]["start"].split('/').last.should == node1["self"].split('/').last
-      batch_result.first["body"][1]["end"].split('/').last.should == node3["self"].split('/').last
-      batch_result.first["body"][1]["self"].should == new_relationship2["self"]
+      expect(batch_result.first["body"].length).to be(2)
+      expect(batch_result.first["body"][0]["type"]).to eq("friends")
+      expect(batch_result.first["body"][0]["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(batch_result.first["body"][0]["end"].split('/').last).to eq(node2["self"].split('/').last)
+      expect(batch_result.first["body"][0]["self"]).to eq(new_relationship1["self"])
+      expect(batch_result.first["body"][1]["type"]).to eq("brothers")
+      expect(batch_result.first["body"][1]["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(batch_result.first["body"][1]["end"].split('/').last).to eq(node3["self"].split('/').last)
+      expect(batch_result.first["body"][1]["self"]).to eq(new_relationship2["self"])
     end
 
     it "can get relationships of specific type" do
@@ -509,11 +509,11 @@ describe Neography::Rest do
       new_relationship1 = @neo.create_relationship("friends", node1, node2)
       new_relationship2 = @neo.create_relationship("brothers", node1, node3)
       batch_result = @neo.batch [:get_node_relationships, node1, "out", "friends"]
-      batch_result.first["body"].length.should be(1)
-      batch_result.first["body"][0]["type"].should == "friends"
-      batch_result.first["body"][0]["start"].split('/').last.should == node1["self"].split('/').last
-      batch_result.first["body"][0]["end"].split('/').last.should == node2["self"].split('/').last
-      batch_result.first["body"][0]["self"].should == new_relationship1["self"]
+      expect(batch_result.first["body"].length).to be(1)
+      expect(batch_result.first["body"][0]["type"]).to eq("friends")
+      expect(batch_result.first["body"][0]["start"].split('/').last).to eq(node1["self"].split('/').last)
+      expect(batch_result.first["body"][0]["end"].split('/').last).to eq(node2["self"].split('/').last)
+      expect(batch_result.first["body"][0]["self"]).to eq(new_relationship1["self"])
     end
 
     it "can create a relationship from a unique node" do
@@ -521,7 +521,7 @@ describe Neography::Rest do
                                 [:add_node_to_index, "person_ssn", "ssn", "000-00-0001", "{0}"],
                                 [:create_unique_node, "person", "ssn", "000-00-0001", {:first_name=>"Jane", :last_name=>"Doe", :ssn=>"000-00-0001", :_type=>"Person", :created_at=>1335269478}],
                                 [:create_relationship, "has", "{0}", "{2}", {}]
-      batch_result.should_not be_nil
+      expect(batch_result).not_to be_nil
 
       # create_unique_node is returning an index result, not a node, so we can't do this yet.
       # See https://github.com/neo4j/community/issues/697
@@ -539,12 +539,12 @@ describe Neography::Rest do
                                   [:create_node, {:street1=>"94437 Kemmer Crossing", :street2=>"Apt. 333", :city=>"Abshireton", :state=>"AA", :zip=>"65820", :_type=>"Address", :created_at=>1335269478}],
                                   [:create_relationship, "has", "{0}", "{2}", {}]
       rescue Neography::NeographyError => e
-        e.message.should == "Not Found"
-        e.code.should == 404
-        e.stacktrace.should be_nil
-        e.request[:path].should == "/db/data/batch"
-        e.request[:body].should_not be_nil
-        e.index.should == 3
+        expect(e.message).to eq("Not Found")
+        expect(e.code).to eq(404)
+        expect(e.stacktrace).to be_nil
+        expect(e.request[:path]).to eq("/db/data/batch")
+        expect(e.request[:body]).not_to be_nil
+        expect(e.index).to eq(3)
       end            
     end
 

--- a/spec/integration/rest_batch_streaming_spec.rb
+++ b/spec/integration/rest_batch_streaming_spec.rb
@@ -13,8 +13,8 @@ describe Neography::Rest do
         commands << [:create_node, {"name" => "Max " + x.to_s}]
       end
       batch_result = @neo.batch *commands
-      batch_result.first["body"]["data"]["name"].should == "Max 0"
-      batch_result.last["body"]["data"]["name"].should == "Max 999"
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max 0")
+      expect(batch_result.last["body"]["data"]["name"]).to eq("Max 999")
     end
 
     it "can send a 5000 item batch" do
@@ -23,8 +23,8 @@ describe Neography::Rest do
         commands << [:get_node, 0]
       end
       batch_result = @neo.batch *commands
-      batch_result.first["body"]["self"].split('/').last.should == "0"
-      batch_result.last["body"]["self"].split('/').last.should == "0"
+      expect(batch_result.first["body"]["self"].split('/').last).to eq("0")
+      expect(batch_result.last["body"]["self"].split('/').last).to eq("0")
     end
 
     it "can send a 7000 get item batch" do
@@ -33,8 +33,8 @@ describe Neography::Rest do
         commands << [:get_node, 0]
       end
       batch_result = @neo.batch *commands
-      batch_result.first["body"]["self"].split('/').last.should == "0"
-      batch_result.last["body"]["self"].split('/').last.should == "0"
+      expect(batch_result.first["body"]["self"].split('/').last).to eq("0")
+      expect(batch_result.last["body"]["self"].split('/').last).to eq("0")
     end
 
     it "can send a 5000 create item batch" do
@@ -43,8 +43,8 @@ describe Neography::Rest do
         commands << [:create_node, {"name" => "Max " + x.to_s}]
       end
       batch_result = @neo.batch *commands
-      batch_result.first["body"]["data"]["name"].should == "Max 0"
-      batch_result.last["body"]["data"]["name"].should == "Max 4999"
+      expect(batch_result.first["body"]["data"]["name"]).to eq("Max 0")
+      expect(batch_result.last["body"]["data"]["name"]).to eq("Max 4999")
     end
 
   end

--- a/spec/integration/rest_bulk_spec.rb
+++ b/spec/integration/rest_bulk_spec.rb
@@ -8,8 +8,8 @@ describe Neography::Rest do
   describe "can create many nodes threaded" do
     it "can create empty nodes threaded" do
       new_nodes = @neo.create_nodes_threaded(2)
-      new_nodes.should_not be_nil
-      new_nodes.size.should == 2
+      expect(new_nodes).not_to be_nil
+      expect(new_nodes.size).to eq(2)
     end
 
     it "is faster than non-threaded?" , :slow => true do
@@ -19,9 +19,9 @@ describe Neography::Rest do
         x.report("create 1000 nodes threaded") { @threaded2c   = @neo.create_nodes_threaded(1000) }
       end
 
-      @not_threaded[99].should_not be_nil
-      @threaded[99].should_not be_nil
-      @threaded2c[199].should_not be_nil
+      expect(@not_threaded[99]).not_to be_nil
+      expect(@threaded[99]).not_to be_nil
+      expect(@threaded2c[199]).not_to be_nil
     end
 
   end
@@ -29,36 +29,36 @@ describe Neography::Rest do
   describe "can create many nodes" do
     it "can create empty nodes" do
       new_nodes = @neo.create_nodes(2)
-      new_nodes.should_not be_nil
-      new_nodes.size.should == 2
+      expect(new_nodes).not_to be_nil
+      expect(new_nodes.size).to eq(2)
     end
 
     it "can create nodes with one property" do
       new_nodes = @neo.create_nodes([{"name" => "Max"}, {"name" => "Alex"}])
-      new_nodes[0]["data"]["name"].should == "Max"
-      new_nodes[1]["data"]["name"].should == "Alex"
+      expect(new_nodes[0]["data"]["name"]).to eq("Max")
+      expect(new_nodes[1]["data"]["name"]).to eq("Alex")
     end
 
     it "can create nodes with one property that are different" do
       new_nodes = @neo.create_nodes([{"name" => "Max"}, {"age" => 24}])
-      new_nodes[0]["data"]["name"].should == "Max"
-      new_nodes[1]["data"]["age"].should == 24
+      expect(new_nodes[0]["data"]["name"]).to eq("Max")
+      expect(new_nodes[1]["data"]["age"]).to eq(24)
     end
 
     it "can create nodes with more than one property" do
       new_nodes = @neo.create_nodes([{"age" => 31, "name" => "Max"}, {"age" => 24, "name" => "Alex"}])
-      new_nodes[0]["data"]["name"].should == "Max"
-      new_nodes[0]["data"]["age"].should == 31
-      new_nodes[1]["data"]["name"].should == "Alex"
-      new_nodes[1]["data"]["age"].should == 24
+      expect(new_nodes[0]["data"]["name"]).to eq("Max")
+      expect(new_nodes[0]["data"]["age"]).to eq(31)
+      expect(new_nodes[1]["data"]["name"]).to eq("Alex")
+      expect(new_nodes[1]["data"]["age"]).to eq(24)
     end
 
     it "can create nodes with more than one property that are different" do
       new_nodes = @neo.create_nodes([{"age" => 31, "name" => "Max"}, {"height" => "5-11", "weight" => 215}])
-      new_nodes[0]["data"]["name"].should == "Max"
-      new_nodes[0]["data"]["age"].should == 31
-      new_nodes[1]["data"]["height"].should == "5-11"
-      new_nodes[1]["data"]["weight"].should == 215
+      expect(new_nodes[0]["data"]["name"]).to eq("Max")
+      expect(new_nodes[0]["data"]["age"]).to eq(31)
+      expect(new_nodes[1]["data"]["height"]).to eq("5-11")
+      expect(new_nodes[1]["data"]["weight"]).to eq(215)
     end
 
     it "is not super slow?" , :slow => true do
@@ -74,8 +74,8 @@ describe Neography::Rest do
     it "can get 2 nodes passed in as an array" do
       new_nodes = @neo.create_nodes(2)
       existing_nodes = @neo.get_nodes(new_nodes)
-      existing_nodes.should_not be_nil
-      existing_nodes.size.should == 2
+      expect(existing_nodes).not_to be_nil
+      expect(existing_nodes.size).to eq(2)
     end
 
     it "can get 2 nodes passed in by commas" do
@@ -83,8 +83,8 @@ describe Neography::Rest do
       new_node1 = new_nodes[0]["self"].split('/').last
       new_node2 = new_nodes[1]["self"].split('/').last
       existing_nodes = @neo.get_nodes(new_node1, new_node2)
-      existing_nodes.should_not be_nil
-      existing_nodes.size.should == 2
+      expect(existing_nodes).not_to be_nil
+      expect(existing_nodes.size).to eq(2)
       existing_nodes[0]["self"] == new_node1["self"]
       existing_nodes[1]["self"] == new_node2["self"]
     end

--- a/spec/integration/rest_constraints_spec.rb
+++ b/spec/integration/rest_constraints_spec.rb
@@ -10,9 +10,9 @@ describe Neography::Rest do
       label = "User"
       property = "user_id"
       uc = @neo.create_unique_constraint(label, property)
-      uc.should_not be_nil
-      uc["label"].should == label
-      uc["property_keys"].should == [property]
+      expect(uc).not_to be_nil
+      expect(uc["label"]).to eq(label)
+      expect(uc["property_keys"]).to eq([property])
     end
   end
 
@@ -21,9 +21,9 @@ describe Neography::Rest do
       label = "User"
       property = "user_id"
       uc = @neo.get_unique_constraint(label, property)
-      uc.should_not be_nil
-      uc.first["label"].should == label
-      uc.first["property_keys"].should == [property]
+      expect(uc).not_to be_nil
+      expect(uc.first["label"]).to eq(label)
+      expect(uc.first["property_keys"]).to eq([property])
     end
   end
 
@@ -32,9 +32,9 @@ describe Neography::Rest do
       label = "User"
       property = "user_id"
       uc = @neo.get_uniqueness(label)
-      uc.should_not be_nil
-      uc.first["label"].should == label
-      uc.first["property_keys"].should == [property]
+      expect(uc).not_to be_nil
+      expect(uc.first["label"]).to eq(label)
+      expect(uc.first["property_keys"]).to eq([property])
     end
   end
   
@@ -43,18 +43,18 @@ describe Neography::Rest do
       label = "User"
       property = "user_id"
       cs = @neo.get_constraints
-      cs.should_not be_nil
-      cs.first["label"].should == label
-      cs.first["property_keys"].should == [property]
+      expect(cs).not_to be_nil
+      expect(cs.first["label"]).to eq(label)
+      expect(cs.first["property_keys"]).to eq([property])
     end
 
     it "can get a list of constraints for a specifc label" do
       label = "User"
       property = "user_id"
       cs = @neo.get_constraints(label)
-      cs.should_not be_nil
-      cs.first["label"].should == label
-      cs.first["property_keys"].should == [property]
+      expect(cs).not_to be_nil
+      expect(cs.first["label"]).to eq(label)
+      expect(cs.first["property_keys"]).to eq([property])
     end
   end
   
@@ -63,9 +63,9 @@ describe Neography::Rest do
       label = "User"
       property = "user_id"
       uc = @neo.drop_constraint(label, property)
-      uc.should be_nil
+      expect(uc).to be_nil
       cs = @neo.get_constraints(label)
-      cs.should be_empty
+      expect(cs).to be_empty
     end
   end
     

--- a/spec/integration/rest_experimental_spec.rb
+++ b/spec/integration/rest_experimental_spec.rb
@@ -9,14 +9,14 @@ describe Neography::Rest do
   describe "get_nodes", :slow => true do
     it "can get nodes that exists" do
       existing_nodes = @neo.get_nodes
-      existing_nodes.should_not be_nil
+      expect(existing_nodes).not_to be_nil
     end
 
     it "can get all nodes that exists the ugly way" do
       new_node = @neo.create_node
       last_node_id = new_node["self"].split('/').last.to_i
       existing_nodes = @neo.get_nodes((1..last_node_id).to_a)
-      existing_nodes.should_not be_nil
+      expect(existing_nodes).not_to be_nil
     end
   end
 end

--- a/spec/integration/rest_gremlin_fail_spec.rb
+++ b/spec/integration/rest_gremlin_fail_spec.rb
@@ -18,8 +18,8 @@ describe Neography::Rest do
 
     it "gremlin works", :gremlin => true  do
       root_node = @neo.execute_script("g.v(0)")
-      root_node.should have_key("self")
-      root_node["self"].split('/').last.should == "0"
+      expect(root_node).to have_key("self")
+      expect(root_node["self"].split('/').last).to eq("0")
     end
   end
 
@@ -37,8 +37,8 @@ describe Neography::Rest do
 
     it "gremlin works", :gremlin => true  do
       root_node = @neo.execute_script("g.v(0)")
-      root_node.should have_key("self")
-      root_node["self"].split('/').last.should == "0"
+      expect(root_node).to have_key("self")
+      expect(root_node["self"].split('/').last).to eq("0")
     end
   end
 

--- a/spec/integration/rest_header_spec.rb
+++ b/spec/integration/rest_header_spec.rb
@@ -3,12 +3,13 @@ require 'spec_helper'
 describe Neography::Connection do
 
   it "should not add a content-type header if there's no existing headers" do
-    subject.merge_options({}).keys.should == []
+    expect(subject.merge_options({}).keys).to eq([])
   end
 
   it "should add a content type if there's existing headers" do
-    subject.merge_options({:headers => {'Content-Type' => 'foo/bar'}})[:headers].should ==
+    expect(subject.merge_options({:headers => {'Content-Type' => 'foo/bar'}})[:headers]).to eq(
       {'Content-Type' => "foo/bar",  "User-Agent"   => "Neography/#{Neography::VERSION}" , "X-Stream"=>true, "max-execution-time"=>6000}
+    )
   end
 
 end

--- a/spec/integration/rest_index_spec.rb
+++ b/spec/integration/rest_index_spec.rb
@@ -11,7 +11,7 @@ describe Neography::Rest do
       key = generate_text(6)
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
-      @neo.list_indexes.should_not be_nil
+      expect(@neo.list_indexes).not_to be_nil
     end
 
     it "can get a listing of relationship indexes" do
@@ -21,7 +21,7 @@ describe Neography::Rest do
       key = generate_text(6)
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
-      @neo.list_relationship_indexes.should_not be_nil
+      expect(@neo.list_relationship_indexes).not_to be_nil
     end
   end
 
@@ -29,47 +29,47 @@ describe Neography::Rest do
     it "can create a node index" do
       name = generate_text(6)
       new_index = @neo.create_node_index(name)
-      new_index.should_not be_nil
-      new_index["template"].should == "#{@neo.configuration}/db/data/index/node/#{name}/{key}/{value}"
-      new_index["provider"].should == "lucene"
-      new_index["type"].should == "exact"
+      expect(new_index).not_to be_nil
+      expect(new_index["template"]).to eq("#{@neo.configuration}/db/data/index/node/#{name}/{key}/{value}")
+      expect(new_index["provider"]).to eq("lucene")
+      expect(new_index["type"]).to eq("exact")
     end
 
     it "can create a node index with options" do
       name = generate_text(6)
       new_index = @neo.create_node_index(name, "fulltext","lucene")
-      new_index.should_not be_nil
-      new_index["template"].should == "#{@neo.configuration}/db/data/index/node/#{name}/{key}/{value}"
-      new_index["provider"].should == "lucene"
-      new_index["type"].should == "fulltext"
+      expect(new_index).not_to be_nil
+      expect(new_index["template"]).to eq("#{@neo.configuration}/db/data/index/node/#{name}/{key}/{value}")
+      expect(new_index["provider"]).to eq("lucene")
+      expect(new_index["type"]).to eq("fulltext")
     end
 
     it "can create a node index with extra configuration options" do
       name = generate_text(6)
       new_index = @neo.create_node_index(name, "fulltext","lucene", extra: 'extra-value')
-      new_index.should_not be_nil
-      new_index["template"].should == "#{@neo.configuration}/db/data/index/node/#{name}/{key}/{value}"
-      new_index["provider"].should == "lucene"
-      new_index["extra"].should == "extra-value"
-      new_index["type"].should == "fulltext"
+      expect(new_index).not_to be_nil
+      expect(new_index["template"]).to eq("#{@neo.configuration}/db/data/index/node/#{name}/{key}/{value}")
+      expect(new_index["provider"]).to eq("lucene")
+      expect(new_index["extra"]).to eq("extra-value")
+      expect(new_index["type"]).to eq("fulltext")
     end
 
     it "can create a relationship index" do
       name = generate_text(6)
       new_index = @neo.create_relationship_index(name)
-      new_index.should_not be_nil
-      new_index["template"].should == "#{@neo.configuration}/db/data/index/relationship/#{name}/{key}/{value}"
-      new_index["provider"].should == "lucene"
-      new_index["type"].should == "exact"
+      expect(new_index).not_to be_nil
+      expect(new_index["template"]).to eq("#{@neo.configuration}/db/data/index/relationship/#{name}/{key}/{value}")
+      expect(new_index["provider"]).to eq("lucene")
+      expect(new_index["type"]).to eq("exact")
     end
 
     it "can create a relationship index with options" do
       name = generate_text(6)
       new_index = @neo.create_relationship_index(name, "fulltext","lucene")
-      new_index.should_not be_nil
-      new_index["template"].should == "#{@neo.configuration}/db/data/index/relationship/#{name}/{key}/{value}"
-      new_index["provider"].should == "lucene"
-      new_index["type"].should == "fulltext"
+      expect(new_index).not_to be_nil
+      expect(new_index["template"]).to eq("#{@neo.configuration}/db/data/index/relationship/#{name}/{key}/{value}")
+      expect(new_index["provider"]).to eq("lucene")
+      expect(new_index["type"]).to eq("fulltext")
     end
 
 
@@ -82,7 +82,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_node_from_index("test_node_index", key, value, new_node) 
     end
   
@@ -94,7 +94,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_relationship_from_index("test_relationship_index", key, value, new_relationship) 
     end
   end
@@ -106,10 +106,10 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_node_from_index("test_node_index", key, value, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should be_nil
+      expect(new_index).to be_nil
     end
 
     it "can remove a node from an index without supplying value" do
@@ -118,10 +118,10 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_node_from_index("test_node_index", key, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should be_nil
+      expect(new_index).to be_nil
     end
 
     it "can remove a node from an index without supplying key nor value" do
@@ -130,10 +130,10 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_node_from_index("test_node_index", new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should be_nil
+      expect(new_index).to be_nil
     end
 
     it "can remove a relationship from an index" do
@@ -144,10 +144,10 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_relationship_from_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.should be_nil
+      expect(new_index).to be_nil
     end
 
     it "can remove a relationship from an index without supplying value" do
@@ -158,10 +158,10 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_relationship_from_index("test_relationship_index", key, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.should be_nil
+      expect(new_index).to be_nil
     end
 
     it "can remove a relationship from an index without supplying key nor value" do
@@ -172,10 +172,10 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_relationship_from_index("test_relationship_index", new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.should be_nil
+      expect(new_index).to be_nil
     end
 
     it "throws an error when there is an empty string in the value when removing a node" do
@@ -184,7 +184,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       expect { @neo.remove_node_from_index("test_node_index", key, "", new_node) }.to raise_error Neography::NeographyError
     end
   end
@@ -196,7 +196,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_node_from_index("test_node_index", key, value, new_node) 
     end
 
@@ -206,7 +206,7 @@ describe Neography::Rest do
       value = generate_text + " " + generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node)
       new_index = @neo.get_node_index("test_node_index", key, value)
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_node_from_index("test_node_index", key, value, new_node)
     end
 
@@ -216,7 +216,7 @@ describe Neography::Rest do
       value = generate_text + "/" + generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node)
       new_index = @neo.get_node_index("test_node_index", key, value)
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_node_from_index("test_node_index", key, value, new_node)
     end
 
@@ -228,7 +228,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.remove_relationship_from_index("test_relationship_index", key, value, new_relationship)
     end
   end
@@ -240,7 +240,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.first["self"].should == new_node["self"]
+      expect(new_index.first["self"]).to eq(new_node["self"])
       @neo.remove_node_from_index("test_node_index", key, value, new_node) 
     end
 
@@ -250,7 +250,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       new_index = @neo.find_node_index("test_node_index", key, value) 
-      new_index.first["self"].should == new_node["self"]
+      expect(new_index.first["self"]).to eq(new_node["self"])
       @neo.remove_node_from_index("test_node_index", key, value, new_node) 
     end
 
@@ -260,7 +260,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node)
       new_index = @neo.find_node_index("test_node_index", "#{key}: #{value}")
-      new_index.first["self"].should == new_node["self"]
+      expect(new_index.first["self"]).to eq(new_node["self"])
       @neo.remove_node_from_index("test_node_index", key, value, new_node)
     end
 
@@ -270,8 +270,8 @@ describe Neography::Rest do
       value = generate_text + ' ' + generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node)
       new_index = @neo.find_node_index("test_node_index", key, value)
-      new_index.should_not be_nil
-      new_index.first["self"].should == new_node["self"]
+      expect(new_index).not_to be_nil
+      expect(new_index.first["self"]).to eq(new_node["self"])
       @neo.remove_node_from_index("test_node_index", key, value, new_node)
     end
 
@@ -281,8 +281,8 @@ describe Neography::Rest do
       value = generate_text + '/' + generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node)
       new_index = @neo.find_node_index("test_node_index", key, value)
-      new_index.should_not be_nil
-      new_index.first["self"].should == new_node["self"]
+      expect(new_index).not_to be_nil
+      expect(new_index.first["self"]).to eq(new_node["self"])
       @neo.remove_node_from_index("test_node_index", key, value, new_node)
     end
 
@@ -294,7 +294,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.first["self"].should == new_relationship["self"]
+      expect(new_index.first["self"]).to eq(new_relationship["self"])
       @neo.remove_relationship_from_index("test_relationship_index", key, value, new_relationship)
     end
 
@@ -306,7 +306,7 @@ describe Neography::Rest do
       value = generate_text + " " + generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.first["self"].should == new_relationship["self"]
+      expect(new_index.first["self"]).to eq(new_relationship["self"])
       @neo.remove_relationship_from_index("test_relationship_index", key, value, new_relationship)
     end
 
@@ -318,7 +318,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.find_relationship_index("test_relationship_index", key, value) 
-      new_index.first["self"].should == new_relationship["self"]
+      expect(new_index.first["self"]).to eq(new_relationship["self"])
       @neo.remove_relationship_from_index("test_relationship_index", key, value, new_relationship)
     end
 
@@ -330,7 +330,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship)
       new_index = @neo.find_relationship_index("test_relationship_index", "#{key}: #{value}")
-      new_index.first["self"].should == new_relationship["self"]
+      expect(new_index.first["self"]).to eq(new_relationship["self"])
       @neo.remove_relationship_from_index("test_relationship_index", key, value, new_relationship)
     end
 
@@ -345,10 +345,10 @@ describe Neography::Rest do
       existing_node1 = @neo.get_node_index("test_node_index", key, value1)
       existing_node2 = @neo.get_node_index("test_node_index", key, value2)
       new_relationship = @neo.create_relationship("friends", existing_node1, existing_node2)
-      new_relationship["start"].should_not be_nil
-      new_relationship["start"].should == new_node1["self"]
-      new_relationship["end"].should_not be_nil
-      new_relationship["end"].should == new_node2["self"]
+      expect(new_relationship["start"]).not_to be_nil
+      expect(new_relationship["start"]).to eq(new_node1["self"])
+      expect(new_relationship["end"]).not_to be_nil
+      expect(new_relationship["end"]).to eq(new_node2["self"])
       @neo.remove_node_from_index("test_node_index", new_node1) 
       @neo.remove_node_from_index("test_node_index", new_node2) 
     end
@@ -358,72 +358,72 @@ describe Neography::Rest do
   describe "auto indexes" do
 
     it "can check the status of node auto index" do
-      @neo.get_node_auto_index_status.should satisfy{|status| [true, false].include?(status)}
+      expect(@neo.get_node_auto_index_status).to satisfy{|status| [true, false].include?(status)}
     end
   
     it "can check the status of relationship auto index" do
-      @neo.get_relationship_auto_index_status.should satisfy{|status| [true, false].include?(status)}
+      expect(@neo.get_relationship_auto_index_status).to satisfy{|status| [true, false].include?(status)}
     end
 
     it "can change the node auto index status" do
       @neo.set_node_auto_index_status(true)
-      @neo.get_node_auto_index_status.should be_true
+      expect(@neo.get_node_auto_index_status).to be_true
     end
 
     it "can change the relationship auto index status" do
       @neo.set_relationship_auto_index_status(true)
-      @neo.get_relationship_auto_index_status.should be_true
+      expect(@neo.get_relationship_auto_index_status).to be_true
     end
 
     it "can get a list of auto indexed node properties" do
       @neo.set_node_auto_index_status(true)
       @neo.create_node_auto_index
       @neo.add_node_auto_index_property("name")
-      @neo.get_node_auto_index_properties.should == ["name"]
+      expect(@neo.get_node_auto_index_properties).to eq(["name"])
     end
 
     it "can get a list of auto indexed relationship properties" do
       @neo.set_relationship_auto_index_status(true)
       @neo.create_relationship_auto_index
       @neo.add_relationship_auto_index_property("weight")
-      @neo.get_relationship_auto_index_properties.should == ["weight"]
+      expect(@neo.get_relationship_auto_index_properties).to eq(["weight"])
     end
 
    it "can remove a property from the auto indexed node properties" do
       @neo.add_node_auto_index_property("name")
       @neo.add_node_auto_index_property("label")
-      @neo.get_node_auto_index_properties.should == ["name", "label"]
+      expect(@neo.get_node_auto_index_properties).to eq(["name", "label"])
       @neo.remove_node_auto_index_property("label")   
-      @neo.get_node_auto_index_properties.should == ["name"]
+      expect(@neo.get_node_auto_index_properties).to eq(["name"])
    end
 
    it "can remove a property from the auto indexed relationship properties" do
       @neo.add_relationship_auto_index_property("weight")
       @neo.add_relationship_auto_index_property("strength")
-      @neo.get_relationship_auto_index_properties.should == ["weight", "strength"]
+      expect(@neo.get_relationship_auto_index_properties).to match_array(["weight", "strength"])
       @neo.remove_relationship_auto_index_property("strength")   
-      @neo.get_relationship_auto_index_properties.should == ["weight"]
+      expect(@neo.get_relationship_auto_index_properties).to eq(["weight"])
    end
 
     it "can get a node from an automatic index" do
       new_node = @neo.create_node("name" => "Max")
       existing_nodes = @neo.get_node_auto_index("name", "Max")
-      existing_nodes.collect{|n| n["self"]}.include?(new_node["self"]).should be_true 
+      expect(existing_nodes.collect{|n| n["self"]}.include?(new_node["self"])).to be_true 
     end
 
     it "can query a node from an automatic index using key value" do
       new_node = @neo.create_node("name" => "Max")
       existing_nodes = @neo.find_node_auto_index("name", "Max")
-      existing_nodes.collect{|n| n["self"]}.include?(new_node["self"]).should be_true 
+      expect(existing_nodes.collect{|n| n["self"]}.include?(new_node["self"])).to be_true 
     end
 
     it "can query a node from an automatic index" do
       new_node = @neo.create_node("name" => "Max")
       existing_nodes = @neo.find_node_auto_index("name:Max")
-      existing_nodes.collect{|n| n["self"]}.include?(new_node["self"]).should be_true
+      expect(existing_nodes.collect{|n| n["self"]}.include?(new_node["self"])).to be_true
       # check that more complex queries are correctly handled
       existing_nodes = @neo.find_node_auto_index("name:Max OR name:Max")
-      existing_nodes.collect{|n| n["self"]}.include?(new_node["self"]).should be_true
+      expect(existing_nodes.collect{|n| n["self"]}.include?(new_node["self"])).to be_true
     end
 
     it "can get a relationship from an automatic index" do
@@ -431,7 +431,7 @@ describe Neography::Rest do
       new_node2 = @neo.create_node("name" => "Peter")
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"weight" => 5})
       existing_rels = @neo.get_relationship_auto_index("weight", 5)
-      existing_rels.collect{|n| n["self"]}.include?(new_relationship["self"]).should be_true 
+      expect(existing_rels.collect{|n| n["self"]}.include?(new_relationship["self"])).to be_true 
     end
 
     it "can query a relationship from an automatic index using key value" do
@@ -439,7 +439,7 @@ describe Neography::Rest do
       new_node2 = @neo.create_node("name" => "Peter")
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"weight" => 5})
       existing_rels = @neo.find_relationship_auto_index("weight", 5)
-      existing_rels.collect{|n| n["self"]}.include?(new_relationship["self"]).should be_true 
+      expect(existing_rels.collect{|n| n["self"]}.include?(new_relationship["self"])).to be_true 
     end
 
     it "can query a relationship from an automatic index" do
@@ -447,7 +447,7 @@ describe Neography::Rest do
       new_node2 = @neo.create_node("name" => "Peter")
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"weight" => 5})
       existing_rels = @neo.find_relationship_auto_index("weight:5")
-      existing_rels.collect{|n| n["self"]}.include?(new_relationship["self"]).should be_true 
+      expect(existing_rels.collect{|n| n["self"]}.include?(new_relationship["self"])).to be_true 
     end
 
   end
@@ -459,7 +459,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_node_to_index("test_node_index", key, value, new_node) 
       new_index = @neo.get_node_index("test_node_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.drop_node_index("test_node_index")
       expect { @neo.get_node_index("test_node_index", key, value) }.to raise_error Neography::NotFoundException
     end
@@ -472,7 +472,7 @@ describe Neography::Rest do
       value = generate_text
       @neo.add_relationship_to_index("test_relationship_index", key, value, new_relationship) 
       new_index = @neo.get_relationship_index("test_relationship_index", key, value) 
-      new_index.should_not be_nil
+      expect(new_index).not_to be_nil
       @neo.drop_relationship_index("test_relationship_index") 
       expect { @neo.get_relationship_index("test_relationship_index", key, value) }.to raise_error Neography::NotFoundException
     end

--- a/spec/integration/rest_labels_spec.rb
+++ b/spec/integration/rest_labels_spec.rb
@@ -9,7 +9,7 @@ describe Neography::Rest do
     it "can get the labels of the database" do
       @neo.set_label(0, "Person")
       labels = @neo.list_labels
-      labels.should include("Person")
+      expect(labels).to include("Person")
     end
   end
 
@@ -18,7 +18,7 @@ describe Neography::Rest do
       new_node = @neo.create_node
       @neo.add_label(new_node, "Person")
       labels = @neo.get_node_labels(new_node)
-      labels.should == ["Person"]
+      expect(labels).to eq(["Person"])
     end
 
     it "can add another label to a node" do
@@ -27,7 +27,7 @@ describe Neography::Rest do
       @neo.add_label(new_node_id, "Actor")
       @neo.add_label(new_node_id, "Director")
       labels = @neo.get_node_labels(new_node_id)
-      labels.should == ["Actor", "Director"]
+      expect(labels).to eq(["Actor", "Director"])
     end
 
     it "can add multiple labels to a node" do
@@ -35,7 +35,7 @@ describe Neography::Rest do
       new_node_id = new_node["self"].split('/').last
       @neo.add_label(new_node_id, ["Actor", "Director"])
       labels = @neo.get_node_labels(new_node_id)
-      labels.should == ["Actor", "Director"]
+      expect(labels).to eq(["Actor", "Director"])
     end
   end
 
@@ -45,7 +45,7 @@ describe Neography::Rest do
       new_node_id = new_node["self"].split('/').last
       @neo.set_label(new_node_id, "Person")
       labels = @neo.get_node_labels(new_node_id)
-      labels.should == ["Person"]
+      expect(labels).to eq(["Person"])
     end
 
     it "can set a label to a node that already had a label" do
@@ -53,7 +53,7 @@ describe Neography::Rest do
       @neo.add_label(new_node, "Actor")
       @neo.set_label(new_node, "Director")
       labels = @neo.get_node_labels(new_node)
-      labels.should == ["Director"]
+      expect(labels).to eq(["Director"])
     end
 
     it "can set multiple labels to a node" do
@@ -61,7 +61,7 @@ describe Neography::Rest do
       new_node_id = new_node["self"].split('/').last
       @neo.set_label(new_node_id, ["Actor", "Director"])
       labels = @neo.get_node_labels(new_node_id)
-      labels.should == ["Actor", "Director"]
+      expect(labels).to eq(["Actor", "Director"])
     end
   end
 
@@ -71,7 +71,7 @@ describe Neography::Rest do
       @neo.set_label(new_node, ["Actor", "Director"])
       @neo.delete_label(new_node, "Actor")
       labels = @neo.get_node_labels(new_node)
-      labels.should == ["Director"]
+      expect(labels).to eq(["Director"])
     end
 
     it "can delete a label from a node that doesn't have one" do
@@ -79,7 +79,7 @@ describe Neography::Rest do
       new_node_id = new_node["self"].split('/').last
       @neo.delete_label(new_node_id, "Actor")
       labels = @neo.get_node_labels(new_node_id)
-      labels.should == []
+      expect(labels).to eq([])
     end
 
     it "cannot delete a label from a node that doesn't exist" do
@@ -97,12 +97,12 @@ describe Neography::Rest do
       new_node_id = new_node["self"].split('/').last
       @neo.set_label(new_node_id, ["Actor", "Director"])
       nodes = @neo.get_nodes_labeled("Actor")
-      nodes.last["self"].split('/').last.should == new_node_id
+      expect(nodes.last["self"].split('/').last).to eq(new_node_id)
     end
 
     it "returns an empty array on non-existing label" do
       nodes = @neo.get_nodes_labeled("do_not_exist")
-      nodes.should == []
+      expect(nodes).to eq([])
     end
   end
 
@@ -112,7 +112,7 @@ describe Neography::Rest do
       new_node_id = new_node["self"].split('/').last
       @neo.set_label(new_node_id, "clown")
       nodes = @neo.find_nodes_labeled("clown", { :name => "max" })
-      nodes.last["self"].split('/').last.should == new_node_id
+      expect(nodes.last["self"].split('/').last).to eq(new_node_id)
     end
 
     it "returns an empty array on non-existing label property" do
@@ -120,7 +120,7 @@ describe Neography::Rest do
       new_node_id = new_node["self"].split('/').last
       @neo.set_label(new_node_id, "clown")
       nodes = @neo.find_nodes_labeled("clown", { :name => "does_not_exist" })
-      nodes.should == []
+      expect(nodes).to eq([])
     end
 
   end

--- a/spec/integration/rest_node_spec.rb
+++ b/spec/integration/rest_node_spec.rb
@@ -10,33 +10,33 @@ describe Neography::Rest do
   describe "get_root" do
     it "can get the root node", :reference => true do
       root_node = @neo.get_root
-      root_node.should have_key("self")
-      root_node["self"].split('/').last.should == "0"
+      expect(root_node).to have_key("self")
+      expect(root_node["self"].split('/').last).to eq("0")
     end
   end
 
   describe "create_node" do
     it "can create an empty node" do
       new_node = @neo.create_node
-      new_node.should_not be_nil
+      expect(new_node).not_to be_nil
     end
 
     it "can create a node with one property" do
       new_node = @neo.create_node("name" => "Max")
-      new_node["data"]["name"].should == "Max"
+      expect(new_node["data"]["name"]).to eq("Max")
     end
 
     it "can create a node with nil properties" do
       new_node = @neo.create_node("name" => "Max", "age" => nil )
-      new_node["data"]["name"].should == "Max"
-      new_node["data"]["age"].should be_nil
+      expect(new_node["data"]["name"]).to eq("Max")
+      expect(new_node["data"]["age"]).to be_nil
     end
 
 
     it "can create a node with more than one property" do
       new_node = @neo.create_node("age" => 31, "name" => "Max")
-      new_node["data"]["name"].should == "Max"
-      new_node["data"]["age"].should == 31
+      expect(new_node["data"]["name"]).to eq("Max")
+      expect(new_node["data"]["age"]).to eq(31)
     end
 
     it "can create a unique node with more than one property" do
@@ -45,13 +45,13 @@ describe Neography::Rest do
       value = generate_text
       @neo.create_node_index(index_name)
       new_node = @neo.create_unique_node(index_name, key, value, {"age" => 31, "name" => "Max"})
-      new_node["data"]["name"].should == "Max"
-      new_node["data"]["age"].should == 31
+      expect(new_node["data"]["name"]).to eq("Max")
+      expect(new_node["data"]["age"]).to eq(31)
       new_node_id = new_node["self"].split('/').last
       existing_node = @neo.create_unique_node(index_name, key, value, {"age" => 39, "name" => "Thomas"})
-      existing_node["self"].split('/').last.should == new_node_id
-      existing_node["data"]["name"].should == "Max"
-      existing_node["data"]["age"].should == 31
+      expect(existing_node["self"].split('/').last).to eq(new_node_id)
+      expect(existing_node["data"]["name"]).to eq("Max")
+      expect(existing_node["data"]["age"]).to eq(31)
     end
 
   end
@@ -61,9 +61,9 @@ describe Neography::Rest do
       new_node = @neo.create_node
       new_node[:id] = new_node["self"].split('/').last
       existing_node = @neo.get_node(new_node)
-      existing_node.should_not be_nil
-      existing_node.should have_key("self")
-      existing_node["self"].split('/').last.should == new_node[:id]
+      expect(existing_node).not_to be_nil
+      expect(existing_node).to have_key("self")
+      expect(existing_node["self"].split('/').last).to eq(new_node[:id])
     end
 
     it "raises an error if it tries to get a node that does not exist" do
@@ -78,10 +78,10 @@ describe Neography::Rest do
       new_node = @neo.create_node("name" => "Ateísmo Sureño")
       new_node[:id] = new_node["self"].split('/').last
       existing_node = @neo.get_node(new_node)
-      existing_node.should_not be_nil
-      existing_node.should have_key("self")
-      existing_node["self"].split('/').last.should == new_node[:id]
-      existing_node["data"]["name"].should == "Ateísmo Sureño"
+      expect(existing_node).not_to be_nil
+      expect(existing_node).to have_key("self")
+      expect(existing_node["self"].split('/').last).to eq(new_node[:id])
+      expect(existing_node["data"]["name"]).to eq("Ateísmo Sureño")
     end
   end
 
@@ -90,8 +90,8 @@ describe Neography::Rest do
       new_node = @neo.create_node
       @neo.set_node_properties(new_node, {"weight" => 200, "eyes" => "brown"})
       existing_node = @neo.get_node(new_node)
-      existing_node["data"]["weight"].should == 200
-      existing_node["data"]["eyes"].should == "brown"
+      expect(existing_node["data"]["weight"]).to eq(200)
+      expect(existing_node["data"]["eyes"]).to eq("brown")
     end
 
     it "it fails to set properties on a node that does not exist" do
@@ -109,9 +109,9 @@ describe Neography::Rest do
       @neo.set_node_properties(new_node, {"weight" => 200, "eyes" => "brown", "hair" => "black"})
       @neo.reset_node_properties(new_node, {"weight" => 190, "eyes" => "blue"})
       existing_node = @neo.get_node(new_node)
-      existing_node["data"]["weight"].should == 190
-      existing_node["data"]["eyes"].should == "blue"
-      existing_node["data"]["hair"].should be_nil
+      expect(existing_node["data"]["weight"]).to eq(190)
+      expect(existing_node["data"]["eyes"]).to eq("blue")
+      expect(existing_node["data"]["hair"]).to be_nil
     end
 
     it "it fails to reset properties on a node that does not exist" do
@@ -127,27 +127,27 @@ describe Neography::Rest do
     it "can get all of a node's properties" do
       new_node = @neo.create_node("weight" => 200, "eyes" => "brown")
       node_properties = @neo.get_node_properties(new_node)
-      node_properties["weight"].should == 200
-      node_properties["eyes"].should == "brown"
+      expect(node_properties["weight"]).to eq(200)
+      expect(node_properties["eyes"]).to eq("brown")
     end
 
     it "can get some of a node's properties" do
       new_node = @neo.create_node("weight" => 200, "eyes" => "brown", "height" => "2m")
       node_properties = @neo.get_node_properties(new_node, ["weight", "height"])
-      node_properties["weight"].should == 200
-      node_properties["height"].should == "2m"
-      node_properties["eyes"].should be_nil
+      expect(node_properties["weight"]).to eq(200)
+      expect(node_properties["height"]).to eq("2m")
+      expect(node_properties["eyes"]).to be_nil
     end
 
     it "returns nil if it gets the properties on a node that does not have any" do
       new_node = @neo.create_node
-      @neo.get_node_properties(new_node).should be_nil
+      expect(@neo.get_node_properties(new_node)).to be_nil
     end
 
     it "raises error if it tries to get some of the properties on a node that does not have any" do
       new_node = @neo.create_node
       expect {
-        @neo.get_node_properties(new_node, ["weight", "height"]).should be_nil
+        expect(@neo.get_node_properties(new_node, ["weight", "height"])).to be_nil
       }.to raise_error Neography::NoSuchPropertyException
     end
 
@@ -155,7 +155,7 @@ describe Neography::Rest do
       new_node = @neo.create_node
       fake_node = new_node["self"].split('/').last.to_i + 1000
       expect {
-        @neo.get_node_properties(fake_node).should be_nil
+        expect(@neo.get_node_properties(fake_node)).to be_nil
       }.to raise_error Neography::NodeNotFoundException
     end
   end
@@ -164,14 +164,14 @@ describe Neography::Rest do
     it "can remove a node's properties" do
       new_node = @neo.create_node("weight" => 200, "eyes" => "brown")
       @neo.remove_node_properties(new_node)
-      @neo.get_node_properties(new_node).should be_nil
+      expect(@neo.get_node_properties(new_node)).to be_nil
     end
 
     it "raises error if it fails to remove the properties of a node that does not exist" do
       new_node = @neo.create_node
       fake_node = new_node["self"].split('/').last.to_i + 1000
       expect {
-        @neo.remove_node_properties(fake_node).should be_nil
+        expect(@neo.remove_node_properties(fake_node)).to be_nil
       }.to raise_error Neography::NodeNotFoundException
     end
 
@@ -179,23 +179,23 @@ describe Neography::Rest do
       new_node = @neo.create_node("weight" => 200, "eyes" => "brown")
       @neo.remove_node_properties(new_node, "weight")
       node_properties = @neo.get_node_properties(new_node)
-      node_properties["weight"].should be_nil
-      node_properties["eyes"].should == "brown"
+      expect(node_properties["weight"]).to be_nil
+      expect(node_properties["eyes"]).to eq("brown")
     end
 
     it "can remove more than one property" do
       new_node = @neo.create_node("weight" => 200, "eyes" => "brown", "height" => "2m")
       @neo.remove_node_properties(new_node, ["weight", "eyes"])
       node_properties = @neo.get_node_properties(new_node)
-      node_properties["weight"].should be_nil
-      node_properties["eyes"].should be_nil
+      expect(node_properties["weight"]).to be_nil
+      expect(node_properties["eyes"]).to be_nil
     end
   end
 
   describe "delete_node" do
     it "can delete an unrelated node" do
       new_node = @neo.create_node
-      @neo.delete_node(new_node).should be_nil
+      expect(@neo.delete_node(new_node)).to be_nil
       expect {
         @neo.get_node(new_node)
       }.to raise_error Neography::NodeNotFoundException
@@ -206,28 +206,28 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       @neo.create_relationship("friends", new_node1, new_node2)
       expect {
-        @neo.delete_node(new_node1).should be_nil
+        expect(@neo.delete_node(new_node1)).to be_nil
       }.to raise_error Neography::OperationFailureException
       existing_node = @neo.get_node(new_node1)
-      existing_node.should_not be_nil
+      expect(existing_node).not_to be_nil
     end
 
     it "raises error if it tries to delete a node that does not exist" do
       new_node = @neo.create_node
       fake_node = new_node["self"].split('/').last.to_i + 1000
       expect {
-        @neo.delete_node(fake_node).should be_nil
+        expect(@neo.delete_node(fake_node)).to be_nil
       }.to raise_error Neography::NodeNotFoundException
     end
 
     it "raises error if it tries to delete a node that has already been deleted" do
       new_node = @neo.create_node
-      @neo.delete_node(new_node).should be_nil
+      expect(@neo.delete_node(new_node)).to be_nil
       expect {
         existing_node = @neo.get_node(new_node)
       }.to raise_error Neography::NodeNotFoundException
       expect {
-        @neo.delete_node(new_node).should be_nil
+        expect(@neo.delete_node(new_node)).to be_nil
       }.to raise_error Neography::NodeNotFoundException
     end
   end
@@ -235,7 +235,7 @@ describe Neography::Rest do
   describe "delete_node!" do
     it "can delete an unrelated node" do
       new_node = @neo.create_node
-      @neo.delete_node!(new_node).should be_nil
+      expect(@neo.delete_node!(new_node)).to be_nil
       expect {
         existing_node = @neo.get_node(new_node)
       }.to raise_error Neography::NodeNotFoundException
@@ -245,7 +245,7 @@ describe Neography::Rest do
       new_node1 = @neo.create_node
       new_node2 = @neo.create_node
       @neo.create_relationship("friends", new_node1, new_node2)
-      @neo.delete_node!(new_node1).should be_nil
+      expect(@neo.delete_node!(new_node1)).to be_nil
       expect {
         existing_node = @neo.get_node(new_node1)
       }.to raise_error Neography::NodeNotFoundException
@@ -255,18 +255,18 @@ describe Neography::Rest do
       new_node = @neo.create_node
       fake_node = new_node["self"].split('/').last.to_i + 1000
       expect {
-        @neo.delete_node!(fake_node).should be_nil
+        expect(@neo.delete_node!(fake_node)).to be_nil
       }.to raise_error Neography::NodeNotFoundException
     end
 
     it "raises error if it tries to delete a node that has already been deleted" do
       new_node = @neo.create_node
-      @neo.delete_node!(new_node).should be_nil
+      expect(@neo.delete_node!(new_node)).to be_nil
       expect {
         existing_node = @neo.get_node(new_node)
       }.to raise_error Neography::NodeNotFoundException
       expect {
-        @neo.delete_node!(new_node).should be_nil
+        expect(@neo.delete_node!(new_node)).to be_nil
       }.to raise_error Neography::NodeNotFoundException
     end
   end

--- a/spec/integration/rest_other_node_relationship_spec.rb
+++ b/spec/integration/rest_other_node_relationship_spec.rb
@@ -11,9 +11,9 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2)
       existing_relationships = @neo.get_node_relationships_to(new_node1, new_node2)
-      existing_relationships[0].should_not be_nil
-      existing_relationships[0].should have_key("self")
-      existing_relationships[0]["self"].should == new_relationship["self"]
+      expect(existing_relationships[0]).not_to be_nil
+      expect(existing_relationships[0]).to have_key("self")
+      expect(existing_relationships[0]["self"]).to eq(new_relationship["self"])
     end
 
     it "returns empty array if it tries to get a relationship that does not exist" do
@@ -22,7 +22,7 @@ describe Neography::Rest do
       new_node3 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2)
       existing_relationship = @neo.get_node_relationships_to(new_node1, new_node3)
-      existing_relationship.should be_empty
+      expect(existing_relationship).to be_empty
     end
   end
 
@@ -32,12 +32,12 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       relationships = @neo.get_node_relationships_to(new_node1, new_node2)
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node1["self"]
-      relationships[0]["end"].should == new_node2["self"]
-      relationships[0]["type"].should == "friends"
-      relationships[0]["data"]["met"].should == "college"
-      relationships[0]["data"]["since"].should == '10-1-2005'
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node1["self"])
+      expect(relationships[0]["end"]).to eq(new_node2["self"])
+      expect(relationships[0]["type"]).to eq("friends")
+      expect(relationships[0]["data"]["met"]).to eq("college")
+      expect(relationships[0]["data"]["since"]).to eq('10-1-2005')
     end
 
     it "can get a node's multiple relationships" do
@@ -47,17 +47,17 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       new_relationship = @neo.create_relationship("enemies", new_node1, new_node2, {"since" => '10-2-2010', "met" => "work"})
       relationships = @neo.get_node_relationships_to(new_node1, new_node2)
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node1["self"]
-      relationships[0]["end"].should == new_node2["self"]
-      relationships[0]["type"].should == "friends"
-      relationships[0]["data"]["met"].should == "college"
-      relationships[0]["data"]["since"].should == '10-1-2005'
-      relationships[1]["start"].should == new_node1["self"]
-      relationships[1]["end"].should == new_node2["self"]
-      relationships[1]["type"].should == "enemies"
-      relationships[1]["data"]["met"].should == "work"
-      relationships[1]["data"]["since"].should == '10-2-2010'
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node1["self"])
+      expect(relationships[0]["end"]).to eq(new_node2["self"])
+      expect(relationships[0]["type"]).to eq("friends")
+      expect(relationships[0]["data"]["met"]).to eq("college")
+      expect(relationships[0]["data"]["since"]).to eq('10-1-2005')
+      expect(relationships[1]["start"]).to eq(new_node1["self"])
+      expect(relationships[1]["end"]).to eq(new_node2["self"])
+      expect(relationships[1]["type"]).to eq("enemies")
+      expect(relationships[1]["data"]["met"]).to eq("work")
+      expect(relationships[1]["data"]["since"]).to eq('10-2-2010')
     end
 
     it "can get all of a node's outgoing relationship" do
@@ -67,13 +67,13 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       new_relationship = @neo.create_relationship("enemies", new_node2, new_node1, {"since" => '10-2-2010', "met" => "work"})
       relationships = @neo.get_node_relationships_to(new_node1, new_node2, "out")
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node1["self"]
-      relationships[0]["end"].should == new_node2["self"]
-      relationships[0]["type"].should == "friends"
-      relationships[0]["data"]["met"].should == "college"
-      relationships[0]["data"]["since"].should == '10-1-2005'
-      relationships[1].should be_nil
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node1["self"])
+      expect(relationships[0]["end"]).to eq(new_node2["self"])
+      expect(relationships[0]["type"]).to eq("friends")
+      expect(relationships[0]["data"]["met"]).to eq("college")
+      expect(relationships[0]["data"]["since"]).to eq('10-1-2005')
+      expect(relationships[1]).to be_nil
     end
 
     it "can get all of a node's incoming relationship" do
@@ -83,13 +83,13 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       new_relationship = @neo.create_relationship("enemies", new_node3, new_node1, {"since" => '10-2-2010', "met" => "work"})
       relationships = @neo.get_node_relationships_to(new_node1, new_node3, "in")
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node3["self"]
-      relationships[0]["end"].should == new_node1["self"]
-      relationships[0]["type"].should == "enemies"
-      relationships[0]["data"]["met"].should == "work"
-      relationships[0]["data"]["since"].should == '10-2-2010'
-      relationships[1].should be_nil
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node3["self"])
+      expect(relationships[0]["end"]).to eq(new_node1["self"])
+      expect(relationships[0]["type"]).to eq("enemies")
+      expect(relationships[0]["data"]["met"]).to eq("work")
+      expect(relationships[0]["data"]["since"]).to eq('10-2-2010')
+      expect(relationships[1]).to be_nil
     end
 
     it "can get a specific type of node relationships" do
@@ -99,13 +99,13 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       new_relationship = @neo.create_relationship("friends", new_node1, new_node3, {"since" => '10-2-2010', "met" => "work"})
       relationships = @neo.get_node_relationships_to(new_node1, new_node2, "all", "friends")
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node1["self"]
-      relationships[0]["end"].should == new_node2["self"]
-      relationships[0]["type"].should == "friends"
-      relationships[0]["data"]["met"].should == "college"
-      relationships[0]["data"]["since"].should == '10-1-2005'
-      relationships[1].should be_nil
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node1["self"])
+      expect(relationships[0]["end"]).to eq(new_node2["self"])
+      expect(relationships[0]["type"]).to eq("friends")
+      expect(relationships[0]["data"]["met"]).to eq("college")
+      expect(relationships[0]["data"]["since"]).to eq('10-1-2005')
+      expect(relationships[1]).to be_nil
     end
 
     it "can get a specific type and direction of a node relationships" do
@@ -117,20 +117,20 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("enemies", new_node1, new_node3, {"since" => '10-2-2010', "met" => "work"})
       new_relationship = @neo.create_relationship("enemies", new_node4, new_node1, {"since" => '10-3-2010', "met" => "gym"})
       relationships = @neo.get_node_relationships_to(new_node1, new_node4, "in", "enemies")
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node4["self"]
-      relationships[0]["end"].should == new_node1["self"]
-      relationships[0]["type"].should == "enemies"
-      relationships[0]["data"]["met"].should == "gym"
-      relationships[0]["data"]["since"].should == '10-3-2010'
-      relationships[1].should be_nil
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node4["self"])
+      expect(relationships[0]["end"]).to eq(new_node1["self"])
+      expect(relationships[0]["type"]).to eq("enemies")
+      expect(relationships[0]["data"]["met"]).to eq("gym")
+      expect(relationships[0]["data"]["since"]).to eq('10-3-2010')
+      expect(relationships[1]).to be_nil
     end
 
     it "returns nil if there are no relationships" do
       new_node1 = @neo.create_node
       new_node2 = @neo.create_node
       relationships = @neo.get_node_relationships_to(new_node1, new_node2)
-      relationships.should be_empty
+      expect(relationships).to be_empty
     end
   end
 

--- a/spec/integration/rest_path_spec.rb
+++ b/spec/integration/rest_path_spec.rb
@@ -11,9 +11,9 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       path = @neo.get_path(new_node1, new_node2, {"type"=> "friends", "direction" => "out"})
-      path["start"].should == new_node1["self"]
-      path["end"].should == new_node2["self"]
-      path["nodes"].should == [new_node1["self"], new_node2["self"]]
+      expect(path["start"]).to eq(new_node1["self"])
+      expect(path["end"]).to eq(new_node2["self"])
+      expect(path["nodes"]).to eq([new_node1["self"], new_node2["self"]])
     end
 
     it "can get the shortest path between two nodes" do
@@ -28,9 +28,9 @@ describe Neography::Rest do
       @neo.create_relationship("friends", new_node4, new_node5)
       @neo.create_relationship("friends", new_node3, new_node5)
       path = @neo.get_path(new_node1, new_node5, {"type"=> "friends", "direction" => "out"}, depth=3, algorithm="shortestPath")
-      path["start"].should == new_node1["self"]
-      path["end"].should == new_node5["self"]
-      path["nodes"].should == [new_node1["self"], new_node2["self"], new_node3["self"], new_node5["self"]]
+      expect(path["start"]).to eq(new_node1["self"])
+      expect(path["end"]).to eq(new_node5["self"])
+      expect(path["nodes"]).to eq([new_node1["self"], new_node2["self"], new_node3["self"], new_node5["self"]])
     end
 
     it "can get the shortest weighted path between two nodes" do
@@ -50,9 +50,9 @@ describe Neography::Rest do
       @neo.set_relationship_properties(rel4_5, {:weight => 1})
       @neo.set_relationship_properties(rel3_5, {:weight => 3})
       path = @neo.get_shortest_weighted_path(new_node1, new_node5, {"type"=> "friends", "direction" => "out"})
-      path.first["start"].should == new_node1["self"]
-      path.first["end"].should == new_node5["self"]
-      path.first["nodes"].should == [new_node1["self"], new_node2["self"], new_node3["self"], new_node4["self"], new_node5["self"]]
+      expect(path.first["start"]).to eq(new_node1["self"])
+      expect(path.first["end"]).to eq(new_node5["self"])
+      expect(path.first["nodes"]).to eq([new_node1["self"], new_node2["self"], new_node3["self"], new_node4["self"], new_node5["self"]])
     end
 
     it "can get a simple path between two nodes" do
@@ -67,9 +67,9 @@ describe Neography::Rest do
       @neo.create_relationship("friends", new_node4, new_node5)
       @neo.create_relationship("friends", new_node3, new_node5)
       path = @neo.get_path(new_node1, new_node5, {"type"=> "friends", "direction" => "out"}, depth=3, algorithm="simplePaths")
-      path["start"].should == new_node1["self"]
-      path["end"].should == new_node5["self"]
-      path["nodes"].should == [new_node1["self"], new_node2["self"], new_node3["self"], new_node5["self"]]
+      expect(path["start"]).to eq(new_node1["self"])
+      expect(path["end"]).to eq(new_node5["self"])
+      expect(path["nodes"]).to eq([new_node1["self"], new_node2["self"], new_node3["self"], new_node5["self"]])
     end
 
     it "fails to get a path between two nodes 3 nodes apart when using max depth of 2" do
@@ -101,9 +101,9 @@ describe Neography::Rest do
       @neo.create_relationship("friends", new_node3, new_node4)
       @neo.create_relationship("friends", new_node4, new_node5)
       path = @neo.get_path(new_node1, new_node5, {"type"=> "friends", "direction" => "out"}, depth=4, algorithm="shortestPath")
-      path["start"].should == new_node1["self"]
-      path["end"].should == new_node5["self"]
-      path["nodes"].should == [new_node1["self"], new_node2["self"], new_node3["self"], new_node4["self"], new_node5["self"]]
+      expect(path["start"]).to eq(new_node1["self"])
+      expect(path["end"]).to eq(new_node5["self"])
+      expect(path["nodes"]).to eq([new_node1["self"], new_node2["self"], new_node3["self"], new_node4["self"], new_node5["self"]])
     end
   end
 
@@ -121,13 +121,13 @@ describe Neography::Rest do
       @neo.create_relationship("friends", new_node4, new_node5)
       @neo.create_relationship("friends", new_node3, new_node5)
       paths = @neo.get_paths(new_node1, new_node5, {"type"=> "friends", "direction" => "out"}, depth=4, algorithm="shortestPath")
-      paths.length.should == 2
-      paths[0]["length"].should == 2
-      paths[0]["start"].should == new_node1["self"]
-      paths[0]["end"].should == new_node5["self"]
-      paths[1]["length"].should == 2
-      paths[1]["start"].should == new_node1["self"]
-      paths[1]["end"].should == new_node5["self"]
+      expect(paths.length).to eq(2)
+      expect(paths[0]["length"]).to eq(2)
+      expect(paths[0]["start"]).to eq(new_node1["self"])
+      expect(paths[0]["end"]).to eq(new_node5["self"])
+      expect(paths[1]["length"]).to eq(2)
+      expect(paths[1]["start"]).to eq(new_node1["self"])
+      expect(paths[1]["end"]).to eq(new_node5["self"])
     end
 
     it "can get all paths between two nodes" do
@@ -143,16 +143,16 @@ describe Neography::Rest do
       @neo.create_relationship("friends", new_node4, new_node5)
       @neo.create_relationship("friends", new_node3, new_node5)
       paths = @neo.get_paths(new_node1, new_node5, {"type"=> "friends", "direction" => "out"}, depth=4, algorithm="allPaths")
-      paths.length.should == 3
-      paths[0]["length"].should == 2
-      paths[0]["start"].should == new_node1["self"]
-      paths[0]["end"].should == new_node5["self"]
-      paths[1]["length"].should == 3
-      paths[1]["start"].should == new_node1["self"]
-      paths[1]["end"].should == new_node5["self"]
-      paths[2]["length"].should == 2
-      paths[2]["start"].should == new_node1["self"]
-      paths[2]["end"].should == new_node5["self"]
+      expect(paths.length).to eq(3)
+      expect(paths[0]["length"]).to eq(2)
+      expect(paths[0]["start"]).to eq(new_node1["self"])
+      expect(paths[0]["end"]).to eq(new_node5["self"])
+      expect(paths[1]["length"]).to eq(3)
+      expect(paths[1]["start"]).to eq(new_node1["self"])
+      expect(paths[1]["end"]).to eq(new_node5["self"])
+      expect(paths[2]["length"]).to eq(2)
+      expect(paths[2]["start"]).to eq(new_node1["self"])
+      expect(paths[2]["end"]).to eq(new_node5["self"])
     end
 
     it "can get all simple paths between two nodes" do
@@ -169,16 +169,16 @@ describe Neography::Rest do
       @neo.create_relationship("friends", new_node4, new_node5)
       @neo.create_relationship("friends", new_node3, new_node5)
       paths = @neo.get_paths(new_node1, new_node5, {"type"=> "friends", "direction" => "out"}, depth=4, algorithm="allSimplePaths")
-      paths.length.should == 3
-      paths[0]["length"].should == 2
-      paths[0]["start"].should == new_node1["self"]
-      paths[0]["end"].should == new_node5["self"]
-      paths[1]["length"].should == 3
-      paths[1]["start"].should == new_node1["self"]
-      paths[1]["end"].should == new_node5["self"]
-      paths[2]["length"].should == 2
-      paths[2]["start"].should == new_node1["self"]
-      paths[2]["end"].should == new_node5["self"]
+      expect(paths.length).to eq(3)
+      expect(paths[0]["length"]).to eq(2)
+      expect(paths[0]["start"]).to eq(new_node1["self"])
+      expect(paths[0]["end"]).to eq(new_node5["self"])
+      expect(paths[1]["length"]).to eq(3)
+      expect(paths[1]["start"]).to eq(new_node1["self"])
+      expect(paths[1]["end"]).to eq(new_node5["self"])
+      expect(paths[2]["length"]).to eq(2)
+      expect(paths[2]["start"]).to eq(new_node1["self"])
+      expect(paths[2]["end"]).to eq(new_node5["self"])
     end
 
     it "can get paths between two nodes of max depth 2" do
@@ -194,13 +194,13 @@ describe Neography::Rest do
       @neo.create_relationship("friends", new_node4, new_node5)
       @neo.create_relationship("friends", new_node3, new_node5)
       paths = @neo.get_paths(new_node1, new_node5, {"type"=> "friends", "direction" => "out"}, depth=2, algorithm="allPaths")
-      paths.length.should == 2
-      paths[0]["length"].should == 2
-      paths[0]["start"].should == new_node1["self"]
-      paths[0]["end"].should == new_node5["self"]
-      paths[1]["length"].should == 2
-      paths[1]["start"].should == new_node1["self"]
-      paths[1]["end"].should == new_node5["self"]    end
+      expect(paths.length).to eq(2)
+      expect(paths[0]["length"]).to eq(2)
+      expect(paths[0]["start"]).to eq(new_node1["self"])
+      expect(paths[0]["end"]).to eq(new_node5["self"])
+      expect(paths[1]["length"]).to eq(2)
+      expect(paths[1]["start"]).to eq(new_node1["self"])
+      expect(paths[1]["end"]).to eq(new_node5["self"])    end
 
     it "can get paths between two nodes of a specific relationship" do
       new_node1 = @neo.create_node
@@ -217,12 +217,12 @@ describe Neography::Rest do
       @neo.create_relationship("classmates", new_node1, new_node3)
       @neo.create_relationship("classmates", new_node3, new_node5)
       paths = @neo.get_paths(new_node1, new_node5, {"type"=> "classmates", "direction" => "out"}, depth=4, algorithm="allPaths")
-      paths[0]["length"].should == 2
-      paths[0]["start"].should == new_node1["self"]
-      paths[0]["end"].should == new_node5["self"]
-      paths[1]["length"].should == 2
-      paths[1]["start"].should == new_node1["self"]
-      paths[1]["end"].should == new_node5["self"]    
+      expect(paths[0]["length"]).to eq(2)
+      expect(paths[0]["start"]).to eq(new_node1["self"])
+      expect(paths[0]["end"]).to eq(new_node5["self"])
+      expect(paths[1]["length"]).to eq(2)
+      expect(paths[1]["start"]).to eq(new_node1["self"])
+      expect(paths[1]["end"]).to eq(new_node5["self"])    
     end
 
   end

--- a/spec/integration/rest_plugin_spec.rb
+++ b/spec/integration/rest_plugin_spec.rb
@@ -10,47 +10,47 @@ describe Neography::Rest do
   describe "execute gremlin script" do
     it "can get the root node id", :gremlin => true do
       root_node = @neo.execute_script("g.v(0)")
-      root_node.should have_key("self")
-      root_node["self"].split('/').last.should == "0"
+      expect(root_node).to have_key("self")
+      expect(root_node["self"].split('/').last).to eq("0")
     end
 
     it "can get the a node", :gremlin => true do
       new_node = @neo.create_node
       id = new_node["self"].split('/').last
       existing_node = @neo.execute_script("g.v(#{id})")
-      existing_node.should_not be_nil
-      existing_node.should have_key("self")
-      existing_node["self"].split('/').last.should == id
+      expect(existing_node).not_to be_nil
+      expect(existing_node).to have_key("self")
+      expect(existing_node["self"].split('/').last).to eq(id)
     end
 
     it "can get the a node with a variable", :gremlin => true do
       new_node = @neo.create_node
       id = new_node["self"].split('/').last
       existing_node = @neo.execute_script("g.v(id)", {:id => id.to_i})
-      existing_node.should_not be_nil
-      existing_node.should have_key("self")
-      existing_node["self"].split('/').last.should == id
+      expect(existing_node).not_to be_nil
+      expect(existing_node).to have_key("self")
+      expect(existing_node["self"].split('/').last).to eq(id)
     end
   end
 
   describe "execute cypher query" do
     it "can get the root node id" do
       root_node = @neo.execute_query("start n=node(0) return n")
-      root_node.should have_key("data")
-      root_node.should have_key("columns")
-      root_node["data"][0][0].should have_key("self")
-      root_node["data"][0][0]["self"].split('/').last.should == "0"
+      expect(root_node).to have_key("data")
+      expect(root_node).to have_key("columns")
+      expect(root_node["data"][0][0]).to have_key("self")
+      expect(root_node["data"][0][0]["self"].split('/').last).to eq("0")
     end
 
     it "can get the a node" do
       new_node = @neo.create_node
       id = new_node["self"].split('/').last
       existing_node = @neo.execute_query("start n=node(#{id}) return n")
-      existing_node.should_not be_nil
-      existing_node.should have_key("data")
-      existing_node.should have_key("columns")
-      existing_node["data"][0][0].should have_key("self")
-      existing_node["data"][0][0]["self"].split('/').last.should == id
+      expect(existing_node).not_to be_nil
+      expect(existing_node).to have_key("data")
+      expect(existing_node).to have_key("columns")
+      expect(existing_node["data"][0][0]).to have_key("self")
+      expect(existing_node["data"][0][0]["self"].split('/').last).to eq(id)
     end
 
     it "can perform a range query" do
@@ -60,14 +60,14 @@ describe Neography::Rest do
       @neo.create_node_index(name, "fulltext","lucene")
       @neo.add_node_to_index(name, "number", 3, new_node) 
       existing_node = @neo.find_node_index(name, "number:[1 TO 5]")
-      existing_node.first["self"].should == new_node["self"]
-      existing_node.first.should_not be_nil
-      existing_node.first["data"]["number"].should == 3
+      expect(existing_node.first["self"]).to eq(new_node["self"])
+      expect(existing_node.first).not_to be_nil
+      expect(existing_node.first["data"]["number"]).to eq(3)
       existing_node = @neo.execute_query("start n=node:#{name}(\"number:[1 TO 5]\") return n")
-      existing_node.should have_key("data")
-      existing_node.should have_key("columns")
-      existing_node["data"][0][0].should have_key("self")
-      existing_node["data"][0][0]["self"].split('/').last.should == id
+      expect(existing_node).to have_key("data")
+      expect(existing_node).to have_key("columns")
+      expect(existing_node["data"][0][0]).to have_key("self")
+      expect(existing_node["data"][0][0]["self"].split('/').last).to eq(id)
     end
 
     it "can perform a range query with a term" do
@@ -78,15 +78,15 @@ describe Neography::Rest do
       @neo.add_node_to_index(name, "number", 3, new_node) 
       @neo.add_node_to_index(name, "name", "max", new_node) 
       existing_node = @neo.find_node_index(name, "name:max AND number:[1 TO 5]")
-      existing_node.first["self"].should == new_node["self"]
-      existing_node.first.should_not be_nil
-      existing_node.first["data"]["number"].should == 3
-      existing_node.first["data"]["name"].should == "Max"
+      expect(existing_node.first["self"]).to eq(new_node["self"])
+      expect(existing_node.first).not_to be_nil
+      expect(existing_node.first["data"]["number"]).to eq(3)
+      expect(existing_node.first["data"]["name"]).to eq("Max")
       existing_node = @neo.execute_query("start n=node:#{name}(\"name:max AND number:[1 TO 5]\") return n")
-      existing_node.should have_key("data")
-      existing_node.should have_key("columns")
-      existing_node["data"][0][0].should have_key("self")
-      existing_node["data"][0][0]["self"].split('/').last.should == id
+      expect(existing_node).to have_key("data")
+      expect(existing_node).to have_key("columns")
+      expect(existing_node["data"][0][0]).to have_key("self")
+      expect(existing_node["data"][0][0]["self"].split('/').last).to eq(id)
     end
 
 
@@ -94,50 +94,50 @@ describe Neography::Rest do
       new_node = @neo.create_node("name" => "Ateísmo Sureño")
       id = new_node["self"].split('/').last
       existing_node = @neo.execute_query("start n=node(#{id}) return n")
-      existing_node.should_not be_nil
-      existing_node.should have_key("data")
-      existing_node.should have_key("columns")
-      existing_node["data"][0][0]["self"].split('/').last.should == id
-      existing_node["data"][0][0]["data"]["name"].should == "Ateísmo Sureño"
+      expect(existing_node).not_to be_nil
+      expect(existing_node).to have_key("data")
+      expect(existing_node).to have_key("columns")
+      expect(existing_node["data"][0][0]["self"].split('/').last).to eq(id)
+      expect(existing_node["data"][0][0]["data"]["name"]).to eq("Ateísmo Sureño")
     end
 
     it "can get the a node with a variable" do
       new_node = @neo.create_node
       id = new_node["self"].split('/').last
       existing_node = @neo.execute_query("start n=node({id}) return n", {:id => id.to_i})
-      existing_node.should_not be_nil
-      existing_node.should have_key("data")
-      existing_node.should have_key("columns")
-      existing_node["data"][0][0].should have_key("self")
-      existing_node["data"][0][0]["self"].split('/').last.should == id
+      expect(existing_node).not_to be_nil
+      expect(existing_node).to have_key("data")
+      expect(existing_node).to have_key("columns")
+      expect(existing_node["data"][0][0]).to have_key("self")
+      expect(existing_node["data"][0][0]["self"].split('/').last).to eq(id)
     end
 
     it "can get the stats of a cypher query" do
       root_node = @neo.execute_query("start n=node(0) return n", nil, {:stats => true})
-      root_node.should have_key("data")
-      root_node.should have_key("columns")
-      root_node.should have_key("stats")
-      root_node["data"][0][0].should have_key("self")
-      root_node["data"][0][0]["self"].split('/').last.should == "0"
+      expect(root_node).to have_key("data")
+      expect(root_node).to have_key("columns")
+      expect(root_node).to have_key("stats")
+      expect(root_node["data"][0][0]).to have_key("self")
+      expect(root_node["data"][0][0]["self"].split('/').last).to eq("0")
     end
 
     it "can get the profile of a cypher query" do
       root_node = @neo.execute_query("start n=node(0) return n", nil, {:profile => true})
-      root_node.should have_key("data")
-      root_node.should have_key("columns")
-      root_node.should have_key("plan")
-      root_node["data"][0][0].should have_key("self")
-      root_node["data"][0][0]["self"].split('/').last.should == "0"
+      expect(root_node).to have_key("data")
+      expect(root_node).to have_key("columns")
+      expect(root_node).to have_key("plan")
+      expect(root_node["data"][0][0]).to have_key("self")
+      expect(root_node["data"][0][0]["self"].split('/').last).to eq("0")
     end
 
     it "can get the stats and profile of a cypher query" do
       root_node = @neo.execute_query("start n=node(0) return n", nil, {:stats => true, :profile => true})
-      root_node.should have_key("data")
-      root_node.should have_key("columns")
-      root_node.should have_key("stats")
-      root_node.should have_key("plan")
-      root_node["data"][0][0].should have_key("self")
-      root_node["data"][0][0]["self"].split('/').last.should == "0"
+      expect(root_node).to have_key("data")
+      expect(root_node).to have_key("columns")
+      expect(root_node).to have_key("stats")
+      expect(root_node).to have_key("plan")
+      expect(root_node["data"][0][0]).to have_key("self")
+      expect(root_node["data"][0][0]["self"].split('/').last).to eq("0")
     end
 
 
@@ -147,7 +147,7 @@ describe Neography::Rest do
         @neo.execute_query("start n=node({id}) return n", {:id => 1})
       }.to raise_error(Neography::BadInputException)
       root_node = @neo.execute_query("start n=node({id}) return n", {:id => 0})
-      root_node.should_not be_nil
+      expect(root_node).not_to be_nil
     end
 
     it "throws an error for an invalid query" do

--- a/spec/integration/rest_relationship_spec.rb
+++ b/spec/integration/rest_relationship_spec.rb
@@ -10,8 +10,8 @@ describe Neography::Rest do
       new_node1 = @neo.create_node
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2)
-      new_relationship["start"].should_not be_nil
-      new_relationship["end"].should_not be_nil
+      expect(new_relationship["start"]).not_to be_nil
+      expect(new_relationship["end"]).not_to be_nil
     end
 
     it "can create a relationship with one property" do
@@ -20,15 +20,15 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_node2[:id] = new_node2["self"].split('/').last
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2010'})
-      new_relationship["data"]["since"].should == '10-1-2010'
+      expect(new_relationship["data"]["since"]).to eq('10-1-2010')
     end
 
     it "can create a relationship with more than one property" do
       new_node1 = @neo.create_node
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2010', "met" => "college"})
-      new_relationship["data"]["since"].should == '10-1-2010'
-      new_relationship["data"]["met"].should == "college"
+      expect(new_relationship["data"]["since"]).to eq('10-1-2010')
+      expect(new_relationship["data"]["met"]).to eq("college")
     end
 
     it "can create a unique node with more than one property" do
@@ -37,8 +37,8 @@ describe Neography::Rest do
       value = generate_text
       @neo.create_node_index(index_name)
       new_node = @neo.create_unique_node(index_name, key, value, {"age" => 31, "name" => "Max"})
-      new_node["data"]["name"].should == "Max"
-      new_node["data"]["age"].should == 31
+      expect(new_node["data"]["name"]).to eq("Max")
+      expect(new_node["data"]["age"]).to eq(31)
     end
 
     it "can create a unique relationship" do
@@ -48,7 +48,7 @@ describe Neography::Rest do
       new_node1 = @neo.create_node
       new_node2 = @neo.create_node
       new_relationship = @neo.create_unique_relationship(index_name, key, value, "friends", new_node1, new_node2)
-      new_relationship["data"][key].should == value
+      expect(new_relationship["data"][key]).to eq(value)
     end
 
   end
@@ -59,9 +59,9 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2)
       existing_relationship = @neo.get_relationship(new_relationship)
-      existing_relationship.should_not be_nil
-      existing_relationship.should have_key("self")
-      existing_relationship["self"].should == new_relationship["self"]
+      expect(existing_relationship).not_to be_nil
+      expect(existing_relationship).to have_key("self")
+      expect(existing_relationship["self"]).to eq(new_relationship["self"])
     end
 
     it "raises error if it tries to get a relationship that does not exist" do
@@ -83,9 +83,9 @@ describe Neography::Rest do
       @neo.set_relationship_properties(new_relationship, {"since" => '10-1-2010', "met" => "college"})
       @neo.set_relationship_properties(new_relationship, {"roommates" => "no"})
       relationship_properties = @neo.get_relationship_properties(new_relationship)
-      relationship_properties["since"].should == '10-1-2010'
-      relationship_properties["met"].should == "college"
-      relationship_properties["roommates"].should == "no"
+      expect(relationship_properties["since"]).to eq('10-1-2010')
+      expect(relationship_properties["met"]).to eq("college")
+      expect(relationship_properties["roommates"]).to eq("no")
     end
 
     it "it fails to set properties on a relationship that does not exist" do
@@ -107,9 +107,9 @@ describe Neography::Rest do
       @neo.set_relationship_properties(new_relationship, {"since" => '10-1-2010', "met" => "college"})
       @neo.reset_relationship_properties(new_relationship, {"roommates" => "no"})
       relationship_properties = @neo.get_relationship_properties(new_relationship)
-      relationship_properties["since"].should be_nil
-      relationship_properties["met"].should be_nil
-      relationship_properties["roommates"].should == "no"
+      expect(relationship_properties["since"]).to be_nil
+      expect(relationship_properties["met"]).to be_nil
+      expect(relationship_properties["roommates"]).to eq("no")
     end
 
     it "it fails to reset properties on a relationship that does not exist" do
@@ -129,8 +129,8 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2010', "met" => "college"})
       relationship_properties = @neo.get_relationship_properties(new_relationship)
-      relationship_properties["since"].should == '10-1-2010'
-      relationship_properties["met"].should == "college"
+      expect(relationship_properties["since"]).to eq('10-1-2010')
+      expect(relationship_properties["met"]).to eq("college")
     end
 
     it "can get some of a relationship's properties" do
@@ -138,9 +138,9 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2010', "met" => "college", "roommates" => "no"})
       relationship_properties = @neo.get_relationship_properties(new_relationship, ["since", "roommates"])
-      relationship_properties["since"].should == '10-1-2010'
-      relationship_properties["met"].should be_nil
-      relationship_properties["roommates"].should == "no"
+      expect(relationship_properties["since"]).to eq('10-1-2010')
+      expect(relationship_properties["met"]).to be_nil
+      expect(relationship_properties["roommates"]).to eq("no")
     end
 
     it "returns nil if it gets the properties on a relationship that does not have any" do
@@ -148,7 +148,7 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2)
       relationship_properties = @neo.get_relationship_properties(new_relationship)
-      relationship_properties.should be_nil
+      expect(relationship_properties).to be_nil
     end
 
     it "raises error if it tries to get some of the properties on a relationship that does not have any" do
@@ -177,7 +177,7 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2010', "met" => "college"})
       @neo.remove_relationship_properties(new_relationship)
-      @neo.get_relationship_properties(new_relationship).should be_nil
+      expect(@neo.get_relationship_properties(new_relationship)).to be_nil
     end
 
     it "raises error if it fails to remove the properties of a relationship that does not exist" do
@@ -196,8 +196,8 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2010', "met" => "college"})
       @neo.remove_relationship_properties(new_relationship, "met")
       relationship_properties = @neo.get_relationship_properties(new_relationship)
-      relationship_properties["met"].should be_nil
-      relationship_properties["since"].should == '10-1-2010'
+      expect(relationship_properties["met"]).to be_nil
+      expect(relationship_properties["since"]).to eq('10-1-2010')
     end
 
     it "can remove more than one relationship property" do
@@ -206,9 +206,9 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2010', "met" => "college", "roommates" => "no"})
       @neo.remove_relationship_properties(new_relationship, ["met", "since"])
       relationship_properties = @neo.get_relationship_properties(new_relationship)
-      relationship_properties["met"].should be_nil
-      relationship_properties["since"].should be_nil
-      relationship_properties["roommates"].should == "no"
+      expect(relationship_properties["met"]).to be_nil
+      expect(relationship_properties["since"]).to be_nil
+      expect(relationship_properties["roommates"]).to eq("no")
     end
   end
 
@@ -219,7 +219,7 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2010', "met" => "college"})
       @neo.delete_relationship(new_relationship)
       relationships = @neo.get_node_relationships(new_node1)
-      relationships.should be_empty
+      expect(relationships).to be_empty
     end
 
     it "raises error if it tries to delete a relationship that does not exist" do
@@ -237,7 +237,7 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2010', "met" => "college"})
       existing_relationship = @neo.delete_relationship(new_relationship)
-      existing_relationship.should be_nil
+      expect(existing_relationship).to be_nil
       expect {
         existing_relationship = @neo.delete_relationship(new_relationship)
       }.to raise_error Neography::RelationshipNotFoundException
@@ -250,12 +250,12 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       relationships = @neo.get_node_relationships(new_node1)
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node1["self"]
-      relationships[0]["end"].should == new_node2["self"]
-      relationships[0]["type"].should == "friends"
-      relationships[0]["data"]["met"].should == "college"
-      relationships[0]["data"]["since"].should == '10-1-2005'
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node1["self"])
+      expect(relationships[0]["end"]).to eq(new_node2["self"])
+      expect(relationships[0]["type"]).to eq("friends")
+      expect(relationships[0]["data"]["met"]).to eq("college")
+      expect(relationships[0]["data"]["since"]).to eq('10-1-2005')
     end
 
     it "can get a node's multiple relationships" do
@@ -265,17 +265,17 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       new_relationship = @neo.create_relationship("enemies", new_node1, new_node3, {"since" => '10-2-2010', "met" => "work"})
       relationships = @neo.get_node_relationships(new_node1)
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node1["self"]
-      relationships[0]["end"].should == new_node2["self"]
-      relationships[0]["type"].should == "friends"
-      relationships[0]["data"]["met"].should == "college"
-      relationships[0]["data"]["since"].should == '10-1-2005'
-      relationships[1]["start"].should == new_node1["self"]
-      relationships[1]["end"].should == new_node3["self"]
-      relationships[1]["type"].should == "enemies"
-      relationships[1]["data"]["met"].should == "work"
-      relationships[1]["data"]["since"].should == '10-2-2010'
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node1["self"])
+      expect(relationships[0]["end"]).to eq(new_node2["self"])
+      expect(relationships[0]["type"]).to eq("friends")
+      expect(relationships[0]["data"]["met"]).to eq("college")
+      expect(relationships[0]["data"]["since"]).to eq('10-1-2005')
+      expect(relationships[1]["start"]).to eq(new_node1["self"])
+      expect(relationships[1]["end"]).to eq(new_node3["self"])
+      expect(relationships[1]["type"]).to eq("enemies")
+      expect(relationships[1]["data"]["met"]).to eq("work")
+      expect(relationships[1]["data"]["since"]).to eq('10-2-2010')
     end
 
     it "can get a node's outgoing relationship" do
@@ -285,13 +285,13 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       new_relationship = @neo.create_relationship("enemies", new_node3, new_node1, {"since" => '10-2-2010', "met" => "work"})
       relationships = @neo.get_node_relationships(new_node1, "out")
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node1["self"]
-      relationships[0]["end"].should == new_node2["self"]
-      relationships[0]["type"].should == "friends"
-      relationships[0]["data"]["met"].should == "college"
-      relationships[0]["data"]["since"].should == '10-1-2005'
-      relationships[1].should be_nil
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node1["self"])
+      expect(relationships[0]["end"]).to eq(new_node2["self"])
+      expect(relationships[0]["type"]).to eq("friends")
+      expect(relationships[0]["data"]["met"]).to eq("college")
+      expect(relationships[0]["data"]["since"]).to eq('10-1-2005')
+      expect(relationships[1]).to be_nil
     end
 
     it "can get a node's incoming relationship" do
@@ -301,13 +301,13 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       new_relationship = @neo.create_relationship("enemies", new_node3, new_node1, {"since" => '10-2-2010', "met" => "work"})
       relationships = @neo.get_node_relationships(new_node1, "in")
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node3["self"]
-      relationships[0]["end"].should == new_node1["self"]
-      relationships[0]["type"].should == "enemies"
-      relationships[0]["data"]["met"].should == "work"
-      relationships[0]["data"]["since"].should == '10-2-2010'
-      relationships[1].should be_nil
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node3["self"])
+      expect(relationships[0]["end"]).to eq(new_node1["self"])
+      expect(relationships[0]["type"]).to eq("enemies")
+      expect(relationships[0]["data"]["met"]).to eq("work")
+      expect(relationships[0]["data"]["since"]).to eq('10-2-2010')
+      expect(relationships[1]).to be_nil
     end
 
     it "can get a specific type of node relationships" do
@@ -317,13 +317,13 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2, {"since" => '10-1-2005', "met" => "college"})
       new_relationship = @neo.create_relationship("enemies", new_node1, new_node3, {"since" => '10-2-2010', "met" => "work"})
       relationships = @neo.get_node_relationships(new_node1, "all", "friends")
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node1["self"]
-      relationships[0]["end"].should == new_node2["self"]
-      relationships[0]["type"].should == "friends"
-      relationships[0]["data"]["met"].should == "college"
-      relationships[0]["data"]["since"].should == '10-1-2005'
-      relationships[1].should be_nil
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node1["self"])
+      expect(relationships[0]["end"]).to eq(new_node2["self"])
+      expect(relationships[0]["type"]).to eq("friends")
+      expect(relationships[0]["data"]["met"]).to eq("college")
+      expect(relationships[0]["data"]["since"]).to eq('10-1-2005')
+      expect(relationships[1]).to be_nil
     end
 
     it "can get a specific type and direction of a node relationships" do
@@ -335,19 +335,19 @@ describe Neography::Rest do
       new_relationship = @neo.create_relationship("enemies", new_node1, new_node3, {"since" => '10-2-2010', "met" => "work"})
       new_relationship = @neo.create_relationship("enemies", new_node4, new_node1, {"since" => '10-3-2010', "met" => "gym"})
       relationships = @neo.get_node_relationships(new_node1, "in", "enemies")
-      relationships.should_not be_nil
-      relationships[0]["start"].should == new_node4["self"]
-      relationships[0]["end"].should == new_node1["self"]
-      relationships[0]["type"].should == "enemies"
-      relationships[0]["data"]["met"].should == "gym"
-      relationships[0]["data"]["since"].should == '10-3-2010'
-      relationships[1].should be_nil
+      expect(relationships).not_to be_nil
+      expect(relationships[0]["start"]).to eq(new_node4["self"])
+      expect(relationships[0]["end"]).to eq(new_node1["self"])
+      expect(relationships[0]["type"]).to eq("enemies")
+      expect(relationships[0]["data"]["met"]).to eq("gym")
+      expect(relationships[0]["data"]["since"]).to eq('10-3-2010')
+      expect(relationships[1]).to be_nil
     end
 
     it "returns nil if there are no relationships" do
       new_node1 = @neo.create_node
       relationships = @neo.get_node_relationships(new_node1)
-      relationships.should be_empty
+      expect(relationships).to be_empty
     end
   end
 

--- a/spec/integration/rest_relationship_types_spec.rb
+++ b/spec/integration/rest_relationship_types_spec.rb
@@ -11,8 +11,8 @@ describe Neography::Rest do
       new_node2 = @neo.create_node
       new_relationship = @neo.create_relationship("friends", new_node1, new_node2)
       rel_types = @neo.list_relationship_types
-      rel_types.should_not be_nil
-      rel_types.should include("friends")
+      expect(rel_types).not_to be_nil
+      expect(rel_types).to include("friends")
     end
   end
 end

--- a/spec/integration/rest_schema_index_spec.rb
+++ b/spec/integration/rest_schema_index_spec.rb
@@ -8,8 +8,8 @@ describe Neography::Rest do
   describe "create a schema index" do
     it "can create a schema index" do
       si = @neo.create_schema_index("person", ["name"]) 
-      si.should_not be_nil
-      si["property_keys"].should include("name")
+      expect(si).not_to be_nil
+      expect(si["property_keys"]).to include("name")
     end
     
   end
@@ -17,16 +17,16 @@ describe Neography::Rest do
   describe "list schema indexes" do
     it "can get a listing of node indexes" do
       si = @neo.get_schema_index("person")
-      si.should_not be_nil
-      si.first["label"].should include("person")
-      si.first["property_keys"].should include("name")
+      expect(si).not_to be_nil
+      expect(si.first["label"]).to include("person")
+      expect(si.first["property_keys"]).to include("name")
     end
   end
   
   describe "drop schema indexes" do
     it "can drop an existing schema index" do
       si = @neo.delete_schema_index("person", "name")
-      si.should be_nil
+      expect(si).to be_nil
     end
   end
 end

--- a/spec/integration/rest_spatial_spec.rb
+++ b/spec/integration/rest_spatial_spec.rb
@@ -8,51 +8,51 @@ describe Neography::Rest do
   describe "find the spatial plugin" do
     it "can get a description of the spatial plugin" do
       si = @neo.get_spatial
-      si.should_not be_nil
-      si["graphdb"]["addEditableLayer"].should_not be_nil
+      expect(si).not_to be_nil
+      expect(si["graphdb"]["addEditableLayer"]).not_to be_nil
     end
   end
 
   describe "add a point layer" do
     it "can add a simple point layer" do
       pl = @neo.add_point_layer("restaurants") 
-      pl.should_not be_nil
-      pl.first["data"]["layer"].should == "restaurants"
-      pl.first["data"]["geomencoder_config"].should == "lon:lat"
+      expect(pl).not_to be_nil
+      expect(pl.first["data"]["layer"]).to eq("restaurants")
+      expect(pl.first["data"]["geomencoder_config"]).to eq("lon:lat")
     end
 
     it "can add a simple point layer with lat and long" do
       pl = @neo.add_point_layer("coffee_shops", "latitude", "longitude") 
-      pl.should_not be_nil
-      pl.first["data"]["layer"].should == "coffee_shops"
-      pl.first["data"]["geomencoder_config"].should == "longitude:latitude"
+      expect(pl).not_to be_nil
+      expect(pl.first["data"]["layer"]).to eq("coffee_shops")
+      expect(pl.first["data"]["geomencoder_config"]).to eq("longitude:latitude")
     end
   end
 
   describe "add an editable layer" do
     it "can add an editable layer" do
       el = @neo.add_editable_layer("zipcodes", "WKT", "wkt") 
-      el.should_not be_nil
-      el.first["data"]["layer"].should == "zipcodes"
-      el.first["data"]["geomencoder_config"].should == "wkt"
+      expect(el).not_to be_nil
+      expect(el.first["data"]["layer"]).to eq("zipcodes")
+      expect(el.first["data"]["geomencoder_config"]).to eq("wkt")
     end
   end
 
   describe "get a spatial layer" do
     it "can get a layer" do
       sl = @neo.get_layer("restaurants")
-      sl.should_not be_nil
-      sl.first["data"]["layer"].should == "restaurants"
+      expect(sl).not_to be_nil
+      expect(sl.first["data"]["layer"]).to eq("restaurants")
     end
   end
 
   describe "create a spatial index" do
     it "can create a spatial index" do
       index = @neo.create_spatial_index("restaurants")
-      index["provider"].should == "spatial"
-      index["geometry_type"].should == "point"
-      index["lat"].should == "lat"
-      index["lon"].should == "lon"
+      expect(index["provider"]).to eq("spatial")
+      expect(index["geometry_type"]).to eq("point")
+      expect(index["lat"]).to eq("lat")
+      expect(index["lon"]).to eq("lon")
     end
   end
 
@@ -60,8 +60,8 @@ describe Neography::Rest do
     it "can add a geometry" do
       geometry = "LINESTRING (15.2 60.1, 15.3 60.1)"
       geo = @neo.add_geometry_to_layer("zipcodes", geometry)
-      geo.should_not be_nil
-      geo.first["data"]["wkt"].should == geometry
+      expect(geo).not_to be_nil
+      expect(geo.first["data"]["wkt"]).to eq(geometry)
     end
   end
 
@@ -69,12 +69,12 @@ describe Neography::Rest do
     it "can update a geometry" do
       geometry = "LINESTRING (15.2 60.1, 15.3 60.1)"
       geo = @neo.add_geometry_to_layer("zipcodes", geometry)
-      geo.should_not be_nil
-      geo.first["data"]["wkt"].should == geometry
+      expect(geo).not_to be_nil
+      expect(geo.first["data"]["wkt"]).to eq(geometry)
       geometry = "LINESTRING (14.7 60.1, 15.3 60.1)"
       existing_geo = @neo.edit_geometry_from_layer("zipcodes", geometry, geo)
-      existing_geo.first["data"]["wkt"].should == geometry
-      existing_geo.first["self"].split('/').last.to_i.should ==  geo.first["self"].split('/').last.to_i 
+      expect(existing_geo.first["data"]["wkt"]).to eq(geometry)
+      expect(existing_geo.first["self"].split('/').last.to_i).to eq(geo.first["self"].split('/').last.to_i) 
     end
   end
 
@@ -82,14 +82,14 @@ describe Neography::Rest do
     it "can add a node to a simple point layer" do
       properties = {:name => "Max's Restaurant", :lat => 41.8819, :lon => 87.6278}
       node = @neo.create_node(properties)
-      node.should_not be_nil
+      expect(node).not_to be_nil
       added = @neo.add_node_to_layer("restaurants", node)
-      added.first["data"]["lat"].should == properties[:lat]
-      added.first["data"]["lon"].should == properties[:lon]
+      expect(added.first["data"]["lat"]).to eq(properties[:lat])
+      expect(added.first["data"]["lon"]).to eq(properties[:lon])
 
       added = @neo.add_node_to_index("restaurants", "dummy", "dummy", node)
-      added["data"]["lat"].should == properties[:lat]
-      added["data"]["lon"].should == properties[:lon]
+      expect(added["data"]["lat"]).to eq(properties[:lat])
+      expect(added["data"]["lon"]).to eq(properties[:lon])
     end
   end
   
@@ -97,10 +97,10 @@ describe Neography::Rest do
     it "can find a geometry in a bounding box" do
       properties = {:name => "Max's Restaurant", :lat => 41.8819, :lon => 87.6278}
       node = @neo.find_geometries_in_bbox("restaurants", 87.5, 87.7, 41.7, 41.9)
-      node.should_not be_empty
-      node.first["data"]["lat"].should == properties[:lat]
-      node.first["data"]["lon"].should == properties[:lon]
-      node.first["data"]["name"].should == "Max's Restaurant"
+      expect(node).not_to be_empty
+      expect(node.first["data"]["lat"]).to eq(properties[:lat])
+      expect(node.first["data"]["lon"]).to eq(properties[:lon])
+      expect(node.first["data"]["name"]).to eq("Max's Restaurant")
     end
     
     it "can find a geometry in a bounding box using cypher" do
@@ -109,9 +109,9 @@ describe Neography::Rest do
       node = @neo.create_node(properties)
       added = @neo.add_node_to_index("geombbcypher", "dummy", "dummy", node)
       existing_node = @neo.execute_query("start node = node:geombbcypher('bbox:[15.0,15.3,60.0,60.2]') return node")
-      existing_node.should_not be_empty
-      existing_node["data"][0][0]["data"]["lat"].should == properties[:lat]
-      existing_node["data"][0][0]["data"]["lon"].should == properties[:lon]
+      expect(existing_node).not_to be_empty
+      expect(existing_node["data"][0][0]["data"]["lat"]).to eq(properties[:lat])
+      expect(existing_node["data"][0][0]["data"]["lon"]).to eq(properties[:lon])
     end
 
     it "can find a geometry in a bounding box using cypher two" do
@@ -120,9 +120,9 @@ describe Neography::Rest do
       node = @neo.create_node(properties)
       added = @neo.add_node_to_spatial_index("geombbcypher2", node)
       existing_node = @neo.execute_query("start node = node:geombbcypher2('bbox:[15.0,15.3,60.0,60.2]') return node")
-      existing_node.should_not be_empty
-      existing_node["data"][0][0]["data"]["lat"].should == properties[:lat]
-      existing_node["data"][0][0]["data"]["lon"].should == properties[:lon]
+      expect(existing_node).not_to be_empty
+      expect(existing_node["data"][0][0]["data"]["lat"]).to eq(properties[:lat])
+      expect(existing_node["data"][0][0]["data"]["lon"]).to eq(properties[:lon])
     end
 
   end
@@ -131,10 +131,10 @@ describe Neography::Rest do
     it "can find a geometry within distance" do
       properties = {:name => "Max's Restaurant", :lat => 41.8819, :lon => 87.6278}
       node = @neo.find_geometries_within_distance("restaurants", 87.627, 41.881, 10)
-      node.should_not be_empty
-      node.first["data"]["lat"].should == properties[:lat]
-      node.first["data"]["lon"].should == properties[:lon]
-      node.first["data"]["name"].should == "Max's Restaurant"
+      expect(node).not_to be_empty
+      expect(node.first["data"]["lat"]).to eq(properties[:lat])
+      expect(node.first["data"]["lon"]).to eq(properties[:lon])
+      expect(node.first["data"]["name"]).to eq("Max's Restaurant")
     end
 
     it "can find a geometry within distance using cypher" do
@@ -143,10 +143,10 @@ describe Neography::Rest do
       node = @neo.create_node(properties)
       added = @neo.add_node_to_index("geowdcypher", "dummy", "dummy", node)
       existing_node = @neo.execute_query("start n = node:geowdcypher({bbox}) return n", {:bbox => "withinDistance:[60.0,15.0,100.0]"})
-      existing_node.should_not be_empty
-      existing_node.should_not be_empty
-      existing_node["data"][0][0]["data"]["lat"].should == properties[:lat]
-      existing_node["data"][0][0]["data"]["lon"].should == properties[:lon]
+      expect(existing_node).not_to be_empty
+      expect(existing_node).not_to be_empty
+      expect(existing_node["data"][0][0]["data"]["lat"]).to eq(properties[:lat])
+      expect(existing_node["data"][0][0]["data"]["lon"]).to eq(properties[:lon])
     end
 
     it "can find a geometry within distance using cypher 2"  do
@@ -155,10 +155,10 @@ describe Neography::Rest do
       node = @neo.create_node(properties)
       added = @neo.add_node_to_spatial_index("geowdcypher2", node)
       existing_node = @neo.execute_query("start n = node:geowdcypher2({bbox}) return n", {:bbox => "withinDistance:[60.0,15.0,100.0]"})
-      existing_node.should_not be_empty
-      existing_node.should_not be_empty
-      existing_node["data"][0][0]["data"]["lat"].should == properties[:lat]
-      existing_node["data"][0][0]["data"]["lon"].should == properties[:lon]
+      expect(existing_node).not_to be_empty
+      expect(existing_node).not_to be_empty
+      expect(existing_node["data"][0][0]["data"]["lat"]).to eq(properties[:lat])
+      expect(existing_node["data"][0][0]["data"]["lon"]).to eq(properties[:lon])
     end
 
   end

--- a/spec/integration/rest_transaction_spec.rb
+++ b/spec/integration/rest_transaction_spec.rb
@@ -8,26 +8,26 @@ describe Neography::Rest do
   describe "start a transaction" do
     it "can start a transaction" do
       tx = @neo.begin_transaction
-      tx.should have_key("transaction")
-      tx["results"].should be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).to be_empty
     end
 
     it "can start a transaction with statements" do
       tx = @neo.begin_transaction("start n=node(0) return n")
-      tx.should have_key("transaction")
-      tx.should have_key("results")
-      tx["results"].should_not be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx).to have_key("results")
+      expect(tx["results"]).not_to be_empty
     end
 
     it "can start a transaction with statements and represent them as a graph" do
       tx = @neo.begin_transaction(["CREATE ( bike:Bike { weight: 10 } ) CREATE ( frontWheel:Wheel { spokes: 3 } ) CREATE ( backWheel:Wheel { spokes: 32 } ) CREATE p1 = bike -[:HAS { position: 1 } ]-> frontWheel CREATE p2 = bike -[:HAS { position: 2 } ]-> backWheel RETURN bike, p1, p2", 
                                  ["row", "graph", "rest"]])
-      tx.should have_key("transaction")
-      tx.should have_key("results")
-      tx["results"].should_not be_empty
-      tx["results"].first["data"].first["row"].should_not be_empty
-      tx["results"].first["data"].first["graph"].should_not be_empty
-      tx["results"].first["data"].first["rest"].should_not be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx).to have_key("results")
+      expect(tx["results"]).not_to be_empty
+      expect(tx["results"].first["data"].first["row"]).not_to be_empty
+      expect(tx["results"].first["data"].first["graph"]).not_to be_empty
+      expect(tx["results"].first["data"].first["rest"]).not_to be_empty
     end
 
 
@@ -36,12 +36,12 @@ describe Neography::Rest do
   describe "keep a transaction" do
     it "can keep a transaction" do
       tx = @neo.begin_transaction
-      tx.should have_key("transaction")
-      tx["results"].should be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).to be_empty
       sleep(1)
       existing_tx = @neo.keep_transaction(tx)
-      existing_tx.should have_key("transaction")
-      existing_tx["transaction"]["expires"].should > tx["transaction"]["expires"]
+      expect(existing_tx).to have_key("transaction")
+      expect(existing_tx["transaction"]["expires"]).to be > tx["transaction"]["expires"]
     end
   end
 
@@ -49,42 +49,42 @@ describe Neography::Rest do
   describe "add to a transaction" do
     it "can add to a transaction" do
       tx = @neo.begin_transaction
-      tx.should have_key("transaction")
-      tx["results"].should be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).to be_empty
       existing_tx = @neo.in_transaction(tx, "start n=node(0) return n")
-      existing_tx.should have_key("transaction")
-      existing_tx.should have_key("results")
-      existing_tx["results"].should_not be_empty
+      expect(existing_tx).to have_key("transaction")
+      expect(existing_tx).to have_key("results")
+      expect(existing_tx["results"]).not_to be_empty
     end
 
     it "can add to a transaction with parameters" do
       tx = @neo.begin_transaction
-      tx.should have_key("transaction")
-      tx["results"].should be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).to be_empty
       existing_tx = @neo.in_transaction(tx, ["start n=node({id}) return n", {:id => 0}])
-      existing_tx.should have_key("transaction")
-      existing_tx.should have_key("results")
-      existing_tx["results"].should_not be_empty
+      expect(existing_tx).to have_key("transaction")
+      expect(existing_tx).to have_key("results")
+      expect(existing_tx["results"]).not_to be_empty
     end    
 
     it "can add to a transaction with representation" do
       tx = @neo.begin_transaction
-      tx.should have_key("transaction")
-      tx["results"].should be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).to be_empty
       existing_tx = @neo.in_transaction(tx, ["start n=node(0) return n", [:row,:rest]])
-      existing_tx.should have_key("transaction")
-      existing_tx.should have_key("results")
-      existing_tx["results"].should_not be_empty
+      expect(existing_tx).to have_key("transaction")
+      expect(existing_tx).to have_key("results")
+      expect(existing_tx["results"]).not_to be_empty
     end    
 
     it "can add to a transaction with parameters and representation" do
       tx = @neo.begin_transaction
-      tx.should have_key("transaction")
-      tx["results"].should be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).to be_empty
       existing_tx = @neo.in_transaction(tx, ["start n=node({id}) return n", {:id => 0}, [:row,:rest]])
-      existing_tx.should have_key("transaction")
-      existing_tx.should have_key("results")
-      existing_tx["results"].should_not be_empty
+      expect(existing_tx).to have_key("transaction")
+      expect(existing_tx).to have_key("results")
+      expect(existing_tx["results"]).not_to be_empty
     end    
     
   end
@@ -92,52 +92,52 @@ describe Neography::Rest do
   describe "commit a transaction" do
     it "can commit an opened empty transaction" do
       tx = @neo.begin_transaction
-      tx.should have_key("transaction")
-      tx["results"].should be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).to be_empty
       existing_tx = @neo.commit_transaction(tx)
-      existing_tx.should have_key("results")
-      existing_tx["results"].should be_empty
+      expect(existing_tx).to have_key("results")
+      expect(existing_tx["results"]).to be_empty
     end
 
     it "can commit an opened transaction" do
       tx = @neo.begin_transaction("start n=node(0) return n")
-      tx.should have_key("transaction")
-      tx["results"].should_not be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).not_to be_empty
       existing_tx = @neo.commit_transaction(tx)
-      existing_tx.should_not have_key("transaction")
-      existing_tx.should have_key("results")
-      existing_tx["results"].should be_empty
+      expect(existing_tx).not_to have_key("transaction")
+      expect(existing_tx).to have_key("results")
+      expect(existing_tx["results"]).to be_empty
     end
     
     it "can commit an opened transaction with new statements" do
       tx = @neo.begin_transaction
-      tx.should have_key("transaction")
-      tx["results"].should be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).to be_empty
       existing_tx = @neo.commit_transaction(tx, "start n=node(0) return n")
-      existing_tx.should_not have_key("transaction")
-      existing_tx.should have_key("results")
-      existing_tx["results"].should_not be_empty
+      expect(existing_tx).not_to have_key("transaction")
+      expect(existing_tx).to have_key("results")
+      expect(existing_tx["results"]).not_to be_empty
     end
 
     it "can commit an new transaction right away" do
       tx = @neo.commit_transaction(["start n=node(0) return n"])
-      tx.should_not have_key("transaction")
-      tx.should have_key("results")
-      tx["results"].should_not be_empty
+      expect(tx).not_to have_key("transaction")
+      expect(tx).to have_key("results")
+      expect(tx["results"]).not_to be_empty
     end
     
     it "can commit an new transaction right away with parameters" do
       tx = @neo.commit_transaction(["start n=node({id}) return n", {:id => 0}])
-      tx.should_not have_key("transaction")
-      tx.should have_key("results")
-      tx["results"].should_not be_empty
+      expect(tx).not_to have_key("transaction")
+      expect(tx).to have_key("results")
+      expect(tx["results"]).not_to be_empty
     end
 
     it "can commit an new transaction right away without parameters" do
       tx = @neo.commit_transaction("start n=node(0) return n")
-      tx.should_not have_key("transaction")
-      tx.should have_key("results")
-      tx["results"].should_not be_empty
+      expect(tx).not_to have_key("transaction")
+      expect(tx).to have_key("results")
+      expect(tx["results"]).not_to be_empty
     end
     
   end
@@ -145,21 +145,21 @@ describe Neography::Rest do
   describe "rollback a transaction" do
     it "can rollback an opened empty transaction" do
       tx = @neo.begin_transaction
-      tx.should have_key("transaction")
-      tx["results"].should be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).to be_empty
       existing_tx = @neo.rollback_transaction(tx)
-      existing_tx.should have_key("results")
-      existing_tx["results"].should be_empty
+      expect(existing_tx).to have_key("results")
+      expect(existing_tx["results"]).to be_empty
     end
 
     it "can rollback an opened transaction" do
       tx = @neo.begin_transaction("start n=node(0) return n")
-      tx.should have_key("transaction")
-      tx["results"].should_not be_empty
+      expect(tx).to have_key("transaction")
+      expect(tx["results"]).not_to be_empty
       existing_tx = @neo.rollback_transaction(tx)
-      existing_tx.should_not have_key("transaction")
-      existing_tx.should have_key("results")
-      existing_tx["results"].should be_empty
+      expect(existing_tx).not_to have_key("transaction")
+      expect(existing_tx).to have_key("results")
+      expect(existing_tx["results"]).to be_empty
     end
   end  
   

--- a/spec/integration/rest_traverse_spec.rb
+++ b/spec/integration/rest_traverse_spec.rb
@@ -18,11 +18,11 @@ describe Neography::Rest do
       @neo.create_relationship("friends", @new_node4, @new_node5)
       @neo.create_relationship("friends", @new_node3, @new_node5)
       nodes = @neo.traverse(@new_node1, "nodes", {"relationships" => {"type"=> "friends", "direction" => "out"}, "depth" => 4} )
-      nodes.should_not be_nil
-      nodes[0]["self"].should == @new_node2["self"]
-      nodes[1]["self"].should == @new_node3["self"]
-      nodes[2]["self"].should == @new_node4["self"]
-      nodes[3]["self"].should == @new_node5["self"]
+      expect(nodes).not_to be_nil
+      expect(nodes[0]["self"]).to eq(@new_node2["self"])
+      expect(nodes[1]["self"]).to eq(@new_node3["self"])
+      expect(nodes[2]["self"]).to eq(@new_node4["self"])
+      expect(nodes[3]["self"]).to eq(@new_node5["self"])
     end
     it "can traverse the graph and return relationships" do
       new_relationship1= @neo.create_relationship("friends", @new_node1, @new_node2)
@@ -32,12 +32,12 @@ describe Neography::Rest do
       new_relationship5= @neo.create_relationship("friends", @new_node3, @new_node5)
 
       relationships = @neo.traverse(@new_node1, "relationships", {"relationships" => {"type"=> "friends", "direction" => "out"}, "depth" => 4} )
-      relationships.should_not be_nil
+      expect(relationships).not_to be_nil
 
-      relationships[0]["self"].should == new_relationship1["self"]
-      relationships[1]["self"].should == new_relationship2["self"]
-      relationships[2]["self"].should == new_relationship3["self"]
-      relationships[3]["self"].should == new_relationship4["self"]
+      expect(relationships[0]["self"]).to eq(new_relationship1["self"])
+      expect(relationships[1]["self"]).to eq(new_relationship2["self"])
+      expect(relationships[2]["self"]).to eq(new_relationship3["self"])
+      expect(relationships[3]["self"]).to eq(new_relationship4["self"])
     end
 
     it "can traverse the graph and return paths" do
@@ -48,12 +48,12 @@ describe Neography::Rest do
       new_relationship5= @neo.create_relationship("friends", @new_node3, @new_node5)
 
       paths = @neo.traverse(@new_node1, "paths", {"relationships" => {"type"=> "friends", "direction" => "out"}, "depth" => 4} )
-      paths.should_not be_nil
+      expect(paths).not_to be_nil
   
-      paths[0]["nodes"].should == [@new_node1["self"], @new_node2["self"]]
-      paths[1]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"]]
-      paths[2]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"]]
-      paths[3]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"], @new_node5["self"]]
+      expect(paths[0]["nodes"]).to eq([@new_node1["self"], @new_node2["self"]])
+      expect(paths[1]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"]])
+      expect(paths[2]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"]])
+      expect(paths[3]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"], @new_node5["self"]])
     end
 
     it "can traverse the graph up to a certain depth" do
@@ -64,12 +64,12 @@ describe Neography::Rest do
       new_relationship5= @neo.create_relationship("friends", @new_node3, @new_node5)
 
       paths = @neo.traverse(@new_node1, "paths", {"relationships" => {"type"=> "friends", "direction" => "out"}, "depth" => 3} )
-      paths.should_not be_nil
+      expect(paths).not_to be_nil
 
-      paths[0]["nodes"].should == [@new_node1["self"], @new_node2["self"]]
-      paths[1]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"]]
-      paths[2]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"]]
-      paths[3]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node5["self"]]
+      expect(paths[0]["nodes"]).to eq([@new_node1["self"], @new_node2["self"]])
+      expect(paths[1]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"]])
+      expect(paths[2]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"]])
+      expect(paths[3]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node5["self"]])
     end
 
     it "can traverse the graph in a certain order" do
@@ -80,12 +80,12 @@ describe Neography::Rest do
       new_relationship5= @neo.create_relationship("friends", @new_node3, @new_node5)
 
       paths = @neo.traverse(@new_node1, "paths", {"order" => "breadth first", "relationships" => {"type"=> "friends", "direction" => "out"}, "depth" => 4} )
-      paths.should_not be_nil
+      expect(paths).not_to be_nil
     
-      paths[0]["nodes"].should == [@new_node1["self"], @new_node2["self"]]
-      paths[1]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"]]
-      paths[2]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"]]
-      paths[3]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node5["self"]]
+      expect(paths[0]["nodes"]).to eq([@new_node1["self"], @new_node2["self"]])
+      expect(paths[1]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"]])
+      expect(paths[2]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"]])
+      expect(paths[3]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node5["self"]])
     end
 
     it "can traverse the graph with a specific uniqueness" do
@@ -98,12 +98,12 @@ describe Neography::Rest do
       new_relationship5= @neo.create_relationship("friends", @new_node3, @new_node5)
 
       paths = @neo.traverse(@new_node1, "paths", {"order" => "breadth first", "uniqueness" => "node global", "relationships" => [{"type"=> "roommates", "direction" => "all"},{"type"=> "friends", "direction" => "out"}], "depth" => 4} )
-      paths.should_not be_nil
+      expect(paths).not_to be_nil
     
-      paths[0]["nodes"].should == [@new_node1["self"], @new_node2["self"]]
-      paths[1]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node5["self"]]
-      paths[2]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"]]
-      paths[3]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"]]
+      expect(paths[0]["nodes"]).to eq([@new_node1["self"], @new_node2["self"]])
+      expect(paths[1]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node5["self"]])
+      expect(paths[2]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"]])
+      expect(paths[3]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"], @new_node4["self"]])
     end
 
     it "can traverse the graph with a prune evaluator" do
@@ -119,10 +119,10 @@ describe Neography::Rest do
                              "depth" => 3,
                              "prune evaluator" => {"language" => "javascript",  "body" => "position.endNode().getProperty('age') < 21;"
                               }} )
-      paths.should_not be_nil
-      paths[0]["nodes"].should == [@new_node1["self"], @new_node2["self"]]
-      paths[1]["nodes"].should == [@new_node1["self"], @new_node2["self"], @new_node3["self"]]
-      paths[2].should be_nil
+      expect(paths).not_to be_nil
+      expect(paths[0]["nodes"]).to eq([@new_node1["self"], @new_node2["self"]])
+      expect(paths[1]["nodes"]).to eq([@new_node1["self"], @new_node2["self"], @new_node3["self"]])
+      expect(paths[2]).to be_nil
     end
 
     it "can traverse the graph with a return filter" do
@@ -134,12 +134,12 @@ describe Neography::Rest do
       nodes = @neo.traverse(@new_node1, "node", {"relationships" => {"type"=> "friends", "direction" => "out"}, 
                                                       "return filter" => {"language" => "builtin", "name" => "all"},
                                                       "depth" => 4} )
-      nodes.should_not be_nil
-      nodes[0]["self"].should == @new_node1["self"]
-      nodes[1]["self"].should == @new_node2["self"]
-      nodes[2]["self"].should == @new_node3["self"]
-      nodes[3]["self"].should == @new_node4["self"]
-      nodes[4]["self"].should == @new_node5["self"]
+      expect(nodes).not_to be_nil
+      expect(nodes[0]["self"]).to eq(@new_node1["self"])
+      expect(nodes[1]["self"]).to eq(@new_node2["self"])
+      expect(nodes[2]["self"]).to eq(@new_node3["self"])
+      expect(nodes[3]["self"]).to eq(@new_node4["self"])
+      expect(nodes[4]["self"]).to eq(@new_node5["self"])
     end
 
 

--- a/spec/integration/unmanaged_spec.rb
+++ b/spec/integration/unmanaged_spec.rb
@@ -8,18 +8,18 @@ describe Neography::Rest do
   describe "call unmanaged extensions", :unmanaged_extensions => true  do
     it "can call a get based unmanaged extension" do
       results = @neo.get_extension('/example/service/queries/fofof/13343')
-      results.should_not be_null
+      expect(results).not_to be_null
     end
     
     it "can call a POST based unmanaged extension" do 
       results = @neo.post_extention('/movie/recommend', {"title" => "Rambo"})
-      results.should_not be_null
+      expect(results).not_to be_null
     end
     
     it "can call a POST based unmanaged extension that uses form-urlencoded" do
       headers = {'Content-Type' =>'application/x-www-form-urlencoded'}
       results = @neo.post_extention('/music/recommend', {"artist" => "Ministry", "song" => "Just one Fix"}, headers)    
-      results.should_not be_null
+      expect(results).not_to be_null
     end
 
   end

--- a/spec/neography_spec.rb
+++ b/spec/neography_spec.rb
@@ -5,16 +5,16 @@ describe Neography do
   describe "::configure" do
 
     it "returns the same configuration" do
-      Neography.configuration.should == Neography.configuration
+      expect(Neography.configuration).to eq(Neography.configuration)
     end
 
     it "returns the Config" do
-      Neography.configuration.should be_a Neography::Config
+      expect(Neography.configuration).to be_a Neography::Config
     end
 
     it "yields the configuration" do
       Neography.configure do |config|
-        config.should == Neography.configuration
+        expect(config).to eq(Neography.configuration)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,10 +27,10 @@ end
 
 def error_response(attributes)
   request_uri = double()
-  request_uri.stub(:request_uri).and_return("")
+  allow(request_uri).to receive(:request_uri).and_return("")
   
   http_header = double()
-  http_header.stub(:request_uri).and_return(request_uri)
+  allow(http_header).to receive(:request_uri).and_return(request_uri)
   
   double(
     http_header: http_header,

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -7,25 +7,100 @@ module Neography
 
     context "defaults" do
 
-      its(:protocol)              { should == 'http://' }
-      its(:server)                { should == 'localhost' }
-      its(:port)                  { should == 7474 }
-      its(:directory)             { should == '' }
-      its(:cypher_path)           { should == '/cypher' }
-      its(:gremlin_path)          { should == '/ext/GremlinPlugin/graphdb/execute_script' }
-      its(:log_file)              { should == 'neography.log' }
-      its(:log_enabled)           { should == false }
-      its(:logger)                { should == nil }
-      its(:slow_log_threshold)    { should == 0 }
-      its(:max_threads)           { should == 20 }
-      its(:authentication)        { should == nil }
-      its(:username)              { should == nil }
-      its(:password)              { should == nil }
-      its(:parser)                { should == MultiJsonParser}
-      its(:max_execution_time)    { should == 6000 }
-      its(:proxy)                 { should == nil }
-      its(:http_send_timeout)     { should == 1200 }
-      its(:http_receive_timeout)  { should == 1200 }
+      describe '#protocol' do
+        subject { super().protocol }
+        it              { should == 'http://' }
+      end
+
+      describe '#server' do
+        subject { super().server }
+        it                { should == 'localhost' }
+      end
+
+      describe '#port' do
+        subject { super().port }
+        it                  { should == 7474 }
+      end
+
+      describe '#directory' do
+        subject { super().directory }
+        it             { should == '' }
+      end
+
+      describe '#cypher_path' do
+        subject { super().cypher_path }
+        it           { should == '/cypher' }
+      end
+
+      describe '#gremlin_path' do
+        subject { super().gremlin_path }
+        it          { should == '/ext/GremlinPlugin/graphdb/execute_script' }
+      end
+
+      describe '#log_file' do
+        subject { super().log_file }
+        it              { should == 'neography.log' }
+      end
+
+      describe '#log_enabled' do
+        subject { super().log_enabled }
+        it           { should == false }
+      end
+
+      describe '#logger' do
+        subject { super().logger }
+        it                { should == nil }
+      end
+
+      describe '#slow_log_threshold' do
+        subject { super().slow_log_threshold }
+        it    { should == 0 }
+      end
+
+      describe '#max_threads' do
+        subject { super().max_threads }
+        it           { should == 20 }
+      end
+
+      describe '#authentication' do
+        subject { super().authentication }
+        it        { should == nil }
+      end
+
+      describe '#username' do
+        subject { super().username }
+        it              { should == nil }
+      end
+
+      describe '#password' do
+        subject { super().password }
+        it              { should == nil }
+      end
+
+      describe '#parser' do
+        subject { super().parser }
+        it                { should == MultiJsonParser}
+      end
+
+      describe '#max_execution_time' do
+        subject { super().max_execution_time }
+        it    { should == 6000 }
+      end
+
+      describe '#proxy' do
+        subject { super().proxy }
+        it                 { should == nil }
+      end
+
+      describe '#http_send_timeout' do
+        subject { super().http_send_timeout }
+        it     { should == 1200 }
+      end
+
+      describe '#http_receive_timeout' do
+        subject { super().http_receive_timeout }
+        it  { should == 1200 }
+      end
 
 
       it "has a hash representation" do
@@ -51,7 +126,7 @@ module Neography
           :http_receive_timeout => 1200
 
         }
-        config.to_hash.should == expected_hash
+        expect(config.to_hash).to eq(expected_hash)
       end
 
     end

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -8,7 +8,7 @@ module Neography
     context "defaults" do
 
       it "intializes with defaults" do
-        connection.configuration.should == "http://localhost:7474"
+        expect(connection.configuration).to eq("http://localhost:7474")
       end
 
     end
@@ -38,26 +38,26 @@ module Neography
         end
 
         it "accepts all options in a hash" do
-          connection.configuration.should == "https://foobar:4242/dir"
+          expect(connection.configuration).to eq("https://foobar:4242/dir")
 
-          connection.protocol.should           == "https://"
-          connection.server.should             == "foobar"
-          connection.port.should               == 4242
-          connection.directory.should          == "/dir"
-          connection.cypher_path.should        == "/cyph"
-          connection.gremlin_path.should       == "/grem"
-          connection.log_file.should           == "neo.log"
-          connection.log_enabled.should        == false
-          connection.slow_log_threshold.should == 0
-          connection.max_threads.should        == 10
-          connection.parser.should             == Foo
+          expect(connection.protocol).to           eq("https://")
+          expect(connection.server).to             eq("foobar")
+          expect(connection.port).to               eq(4242)
+          expect(connection.directory).to          eq("/dir")
+          expect(connection.cypher_path).to        eq("/cyph")
+          expect(connection.gremlin_path).to       eq("/grem")
+          expect(connection.log_file).to           eq("neo.log")
+          expect(connection.log_enabled).to        eq(false)
+          expect(connection.slow_log_threshold).to eq(0)
+          expect(connection.max_threads).to        eq(10)
+          expect(connection.parser).to             eq(Foo)
 
-          connection.authentication.should == {
+          expect(connection.authentication).to eq({
             :foo_auth => {
               :username => "bar",
               :password => "baz"
             }
-          }
+          })
         end
 
         context "httpclient" do
@@ -70,7 +70,7 @@ module Neography
           end
 
           it 'configures send/receive timeout' do
-            Excon.should_receive(:new).with("http://localhost:7474", 
+            expect(Excon).to receive(:new).with("http://localhost:7474", 
                                     :read_timeout => 100, 
                                     :write_timeout => 120,
                                     :persistent=>true, 
@@ -87,13 +87,13 @@ module Neography
         let(:options) { "https://user:pass@somehost:8585/path" }
 
         it "accepts a string as configuration" do
-          connection.configuration.should == "https://somehost:8585/path"
-          connection.authentication.should == {
+          expect(connection.configuration).to eq("https://somehost:8585/path")
+          expect(connection.authentication).to eq({
             :basic_auth => {
               :username => "user",
               :password => "pass"
             }
-          }
+          })
         end
       end
 
@@ -102,22 +102,22 @@ module Neography
     context "requests" do
 
       it "does a GET request" do
-        connection.client.should_receive(:request).with(:method => :get, :path => "/db/data/node/bar", :body => nil, :headers => nil) { double.as_null_object }
+        expect(connection.client).to receive(:request).with(:method => :get, :path => "/db/data/node/bar", :body => nil, :headers => nil) { double.as_null_object }
         connection.get("/node/bar")
       end
 
       it "does a POST request" do
-        connection.client.should_receive(:request).with(:method => :post, :path => "/db/data/node/bar", :body => nil, :headers => nil) { double.as_null_object }
+        expect(connection.client).to receive(:request).with(:method => :post, :path => "/db/data/node/bar", :body => nil, :headers => nil) { double.as_null_object }
         connection.post("/node/bar")
       end
 
       it "does a PUT request" do
-        connection.client.should_receive(:request).with(:method => :put, :path => "/db/data/node/bar", :body => nil, :headers => nil) { double.as_null_object }
+        expect(connection.client).to receive(:request).with(:method => :put, :path => "/db/data/node/bar", :body => nil, :headers => nil) { double.as_null_object }
         connection.put("/node/bar")
       end
 
       it "does a DELETE request" do
-        connection.client.should_receive(:request).with(:method => :delete, :path => "/db/data/node/bar", :body => nil, :headers => nil) { double.as_null_object }
+        expect(connection.client).to receive(:request).with(:method => :delete, :path => "/db/data/node/bar", :body => nil, :headers => nil) { double.as_null_object }
         connection.delete("/node/bar")
       end
 
@@ -131,12 +131,12 @@ module Neography
         end
 
         it "does requests with authentication" do
-          connection.client.should_not_receive(:set_auth).with(
+          expect(connection.client).not_to receive(:set_auth).with(
             "http://localhost:7474/db/data/node/bar",
              "foo",
              "bar") { double.as_null_object }
 
-          connection.client.should_receive(:request).with(
+          expect(connection.client).to receive(:request).with(
             :method => :get, :path => "/db/data/node/bar", :body => nil, :headers => nil) { double.as_null_object }
 
           connection.get("/node/bar")
@@ -144,7 +144,7 @@ module Neography
       end
 
       it "adds the User-Agent to the headers" do
-        connection.client.should_receive(:request).with(
+        expect(connection.client).to receive(:request).with(
             hash_including(
                 {:method => :get, :path => "/db/data/node/bar", :body => nil,
                  :headers => {"User-Agent" => "Neography/#{Neography::VERSION}", "X-Stream"=>true, "max-execution-time" => 6000}}
@@ -158,7 +158,7 @@ module Neography
 
         it "raises NodeNotFoundException" do
           response = error_response(code: 404, message: "a message", exception: "NodeNotFoundException")
-          connection.client.stub(:request).and_return(response)
+          allow(connection.client).to receive(:request).and_return(response)
           expect {
             connection.get("/node/bar")
           }.to raise_error NodeNotFoundException
@@ -166,7 +166,7 @@ module Neography
 
         it "raises OperationFailureException" do
           response = error_response(code: 409, message: "a message", exception: "OperationFailureException")
-          connection.client.stub(:request).and_return(response)
+          allow(connection.client).to receive(:request).and_return(response)
           expect {
             connection.get("/node/bar")
           }.to raise_error OperationFailureException
@@ -174,7 +174,7 @@ module Neography
 
         it "raises PropertyValueException" do
           response = error_response(code: 400, message: "a message", exception: "PropertyValueException")
-          connection.client.stub(:request).and_return(response)
+          allow(connection.client).to receive(:request).and_return(response)
           expect {
             connection.get("/node/bar")
           }.to raise_error PropertyValueException
@@ -182,7 +182,7 @@ module Neography
 
         it "raises NoSuchPropertyException" do
           response = error_response(code: 404, message: "a message", exception: "NoSuchPropertyException")
-          connection.client.stub(:request).and_return(response)
+          allow(connection.client).to receive(:request).and_return(response)
           expect {
             connection.get("/node/bar")
           }.to raise_error NoSuchPropertyException
@@ -190,7 +190,7 @@ module Neography
 
         it "raises RelationshipNotFoundException" do
           response = error_response(code: 404, message: "a message", exception: "RelationshipNotFoundException")
-          connection.client.stub(:request).and_return(response)
+          allow(connection.client).to receive(:request).and_return(response)
           expect {
             connection.get("/node/bar")
           }.to raise_error RelationshipNotFoundException
@@ -198,7 +198,7 @@ module Neography
 
         it "raises BadInputException" do
           response = error_response(code: 400, message: "a message", exception: "BadInputException")
-          connection.client.stub(:request).and_return(response)
+          allow(connection.client).to receive(:request).and_return(response)
           expect {
             connection.get("/node/bar")
           }.to raise_error BadInputException
@@ -206,7 +206,7 @@ module Neography
 
         it "raises UnauthorizedError" do
           response = error_response(code: 401)
-          connection.client.stub(:request).and_return(response)
+          allow(connection.client).to receive(:request).and_return(response)
           expect {
             connection.get("/node/bar")
           }.to raise_error UnauthorizedError
@@ -214,7 +214,7 @@ module Neography
 
         it "raises NeographyError in all other cases" do
           response = error_response(code: 418, message: "I'm a teapot.")
-          connection.client.stub(:request).and_return(response)
+          allow(connection.client).to receive(:request).and_return(response)
           expect {
             connection.get("/node/bar")
           }.to raise_error NeographyError
@@ -222,7 +222,7 @@ module Neography
 
         it "raises BadInputException" do
           response = error_response(code: 500, message: "a message", exception: "JsonParseException")
-          connection.client.stub(:request).and_return(response)
+          allow(connection.client).to receive(:request).and_return(response)
           expect {
             connection.get("/node/bar")
           }.to raise_error NeographyError
@@ -255,19 +255,19 @@ module Neography
 
           describe "slow_log_threshold" do
             before do
-              connection.stub(:evaluate_response).and_return expected_response
+              allow(connection).to receive(:evaluate_response).and_return expected_response
             end
 
             context "default value" do
               it "should have output" do
-                @logger.should_receive(:info).once
+                expect(@logger).to receive(:info).once
               end
             end
 
             context "high value" do
               before { connection.slow_log_threshold = 100_000 }
               it "should not have output" do
-                @logger.should_not_receive(:info)
+                expect(@logger).not_to receive(:info)
               end
             end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -8,22 +8,22 @@ module Neography
 
         before do
           @db = double(Neography::Rest, :is_a? => true).as_null_object
-          Rest.stub(:new) { @db }
+          allow(Rest).to receive(:new) { @db }
         end
 
         it "assigns a new Rest db by default" do
           node = Node.create
-          node.neo_server.should == @db
+          expect(node.neo_server).to eq(@db)
         end
 
         it "creates without arguments" do
-          @db.should_receive(:create_node).with(nil)
+          expect(@db).to receive(:create_node).with(nil)
           Node.create
         end
 
         it "creates with only a hash argument" do
           properties = { :foo => "bar" }
-          @db.should_receive(:create_node).with(properties)
+          expect(@db).to receive(:create_node).with(properties)
           Node.create(properties)
         end
 
@@ -34,7 +34,7 @@ module Neography
         it "cannot pass a server as the first argument, properties as the second (deprecated)" do
           @other_server = Neography::Rest.new
           properties = { :foo => "bar" }
-          @other_server.should_not_receive(:create_node).with(properties)
+          expect(@other_server).not_to receive(:create_node).with(properties)
           expect {
             Node.create(@other_server, properties)
           }.to raise_error(ArgumentError)
@@ -43,7 +43,7 @@ module Neography
         it "can pass properties as the first argument, a server as the second" do
           @other_server = Neography::Rest.new
           properties = { :foo => "bar" }
-          @other_server.should_receive(:create_node).with(properties)
+          expect(@other_server).to receive(:create_node).with(properties)
           Node.create(properties, @other_server)
         end
 
@@ -56,22 +56,22 @@ module Neography
         before do
           # stub out actual connections
           @db = double(Rest).as_null_object
-          Rest.stub(:new) { @db }
+          allow(Rest).to receive(:new) { @db }
         end
 
         it "load by id" do
-          @db.should_receive(:get_node).with(5)
+          expect(@db).to receive(:get_node).with(5)
           Node.load(5)
         end
 
         it "loads by node" do
           node = Node.new
-          @db.should_not_receive(:get_node).with(node)
+          expect(@db).not_to receive(:get_node).with(node)
           Node.load(node)
         end
 
         it "loads by full server string" do
-          @db.should_receive(:get_node).with("http://localhost:7474/db/data/node/2")
+          expect(@db).to receive(:get_node).with("http://localhost:7474/db/data/node/2")
           Node.load("http://localhost:7474/db/data/node/2")
         end
 
@@ -81,7 +81,7 @@ module Neography
 
         it "cannot pass a server as the first argument, node as the second (depracted)" do
           @other_server = Neography::Rest.new
-          @other_server.should_not_receive(:get_node).with(42)
+          expect(@other_server).not_to receive(:get_node).with(42)
           expect {
             node = Node.load(@other_server, 42)
           }.to raise_error(ArgumentError)
@@ -89,7 +89,7 @@ module Neography
 
         it "can pass a node as the first argument, server as the second" do
           @other_server = Neography::Rest.new
-          @other_server.should_receive(:get_node).with(42)
+          expect(@other_server).to receive(:get_node).with(42)
           node = Node.load(42, @other_server)
         end
 

--- a/spec/unit/properties_spec.rb
+++ b/spec/unit/properties_spec.rb
@@ -5,7 +5,7 @@ module Neography
 
     before do
       @db = double(Neography::Rest, :is_a? => true).as_null_object
-      Rest.stub(:new) { @db }
+      allow(Rest).to receive(:new) { @db }
     end
 
     context "Node" do
@@ -17,56 +17,56 @@ module Neography
       end
 
       it "sets properties as accessor" do
-        @db.should_receive(:"set_node_properties").with(42, { "key" => "value" })
+        expect(@db).to receive(:"set_node_properties").with(42, { "key" => "value" })
         node.key = "value"
       end
 
       it "sets properties as array entry" do
-        @db.should_receive(:"set_node_properties").with(42, { "key" => "value" })
+        expect(@db).to receive(:"set_node_properties").with(42, { "key" => "value" })
         node["key"] = "value"
       end
 
       it "gets properties as accessor" do
-        @db.stub(:"set_node_properties")
+        allow(@db).to receive(:"set_node_properties")
         node.key = "value"
-        node.key.should == "value"
+        expect(node.key).to eq("value")
       end
 
       it "gets properties as array entry" do
-        @db.stub(:"set_node_properties")
+        allow(@db).to receive(:"set_node_properties")
         node["key"] = "value"
-        node["key"].should == "value"
+        expect(node["key"]).to eq("value")
       end
 
       it "resets properties as accessor" do
-        @db.should_receive(:"remove_node_properties").with(42, ["key"])
+        expect(@db).to receive(:"remove_node_properties").with(42, ["key"])
         node.key = "value"
         node.key = nil
       end
 
       it "resets properties as array entry" do
-        @db.should_receive(:"remove_node_properties").with(42, ["key"])
+        expect(@db).to receive(:"remove_node_properties").with(42, ["key"])
         node["key"] = "value"
         node["key"] = nil
       end
 
       it "gets unknown properties as nil" do
-        node.unknown.should == nil
+        expect(node.unknown).to eq(nil)
       end
 
       it "overwrites existing properties" do
-        @db.should_receive(:"set_node_properties").with(42, { "key" => "value1" })
+        expect(@db).to receive(:"set_node_properties").with(42, { "key" => "value1" })
         node.key = "value1"
 
-        @db.should_receive(:"set_node_properties").with(42, { "key" => "value2" })
+        expect(@db).to receive(:"set_node_properties").with(42, { "key" => "value2" })
         node.key = "value2"
       end
 
       it "knows its attributes" do
-        @db.stub(:"set_node_properties")
+        allow(@db).to receive(:"set_node_properties")
         node.key = "value"
         node["key2"] = "value"
-        node.attributes.should =~ [ :key, :key2 ]
+        expect(node.attributes).to match_array([ :key, :key2 ])
       end
 
     end
@@ -83,56 +83,56 @@ module Neography
       end
 
       it "sets properties as accessor" do
-        @db.should_receive(:"set_relationship_properties").with(42, { "key" => "value" })
+        expect(@db).to receive(:"set_relationship_properties").with(42, { "key" => "value" })
         relationship.key = "value"
       end
 
       it "sets properties as array entry" do
-        @db.should_receive(:"set_relationship_properties").with(42, { "key" => "value" })
+        expect(@db).to receive(:"set_relationship_properties").with(42, { "key" => "value" })
         relationship["key"] = "value"
       end
 
       it "gets properties as accessor" do
-        @db.stub(:"set_relationship_properties")
+        allow(@db).to receive(:"set_relationship_properties")
         relationship.key = "value"
-        relationship.key.should == "value"
+        expect(relationship.key).to eq("value")
       end
 
       it "gets properties as array entry" do
-        @db.stub(:"set_relationship_properties")
+        allow(@db).to receive(:"set_relationship_properties")
         relationship["key"] = "value"
-        relationship["key"].should == "value"
+        expect(relationship["key"]).to eq("value")
       end
 
       it "resets properties as accessor" do
-        @db.should_receive(:"remove_relationship_properties").with(42, ["key"])
+        expect(@db).to receive(:"remove_relationship_properties").with(42, ["key"])
         relationship.key = "value"
         relationship.key = nil
       end
 
       it "resets properties as array entry" do
-        @db.should_receive(:"remove_relationship_properties").with(42, ["key"])
+        expect(@db).to receive(:"remove_relationship_properties").with(42, ["key"])
         relationship["key"] = "value"
         relationship["key"] = nil
       end
 
       it "gets unknown properties as nil" do
-        relationship.unknown.should == nil
+        expect(relationship.unknown).to eq(nil)
       end
 
       it "overwrites existing properties" do
-        @db.should_receive(:"set_relationship_properties").with(42, { "key" => "value1" })
+        expect(@db).to receive(:"set_relationship_properties").with(42, { "key" => "value1" })
         relationship.key = "value1"
 
-        @db.should_receive(:"set_relationship_properties").with(42, { "key" => "value2" })
+        expect(@db).to receive(:"set_relationship_properties").with(42, { "key" => "value2" })
         relationship.key = "value2"
       end
 
       it "knows its attributes" do
-        @db.stub(:"set_relationship_properties")
+        allow(@db).to receive(:"set_relationship_properties")
         relationship.key = "value"
         relationship["key2"] = "value"
-        relationship.attributes.should =~ [ :key, :key2 ]
+        expect(relationship.attributes).to match_array([ :key, :key2 ])
       end
 
     end

--- a/spec/unit/relationship_spec.rb
+++ b/spec/unit/relationship_spec.rb
@@ -19,19 +19,19 @@ module Neography
 
     describe "::create" do
       it "creates a new node through Rest" do
-        db.should_receive(:create_relationship).with("type", from, to, props)
+        expect(db).to receive(:create_relationship).with("type", from, to, props)
 
         Relationship.create("type", from, to, props)
       end
 
       it "assigns fields" do
-        db.stub(:create_relationship).and_return(relationship_hash)
+        allow(db).to receive(:create_relationship).and_return(relationship_hash)
 
         rel = Relationship.create("type", from, to, props)
 
-        rel.start_node.should == from
-        rel.end_node.should   == to
-        rel.rel_type.should   == "type"
+        expect(rel.start_node).to eq(from)
+        expect(rel.end_node).to   eq(to)
+        expect(rel.rel_type).to   eq("type")
       end
     end
 
@@ -41,22 +41,22 @@ module Neography
         before do
           # stub out actual connections
           @db = double(Rest).as_null_object
-          Rest.stub(:new) { @db }
+          allow(Rest).to receive(:new) { @db }
         end
 
         it "load by id" do
-          @db.should_receive(:get_relationship).with(5)
+          expect(@db).to receive(:get_relationship).with(5)
           Relationship.load(5)
         end
 
         it "loads by relationship" do
           relationship = Relationship.new(relationship_hash)
-          @db.should_receive(:get_relationship).with(relationship)
+          expect(@db).to receive(:get_relationship).with(relationship)
           Relationship.load(relationship)
         end
 
         it "loads by full server string" do
-          @db.should_receive(:get_relationship).with("http://localhost:7474/db/data/relationship/2")
+          expect(@db).to receive(:get_relationship).with("http://localhost:7474/db/data/relationship/2")
           Relationship.load("http://localhost:7474/db/data/relationship/2")
         end
 
@@ -66,7 +66,7 @@ module Neography
 
         it "cannot pass a server as the first argument, relationship as the second" do
           @other_server = Neography::Rest.new
-          @other_server.should_not_receive(:get_relationship).with(42)
+          expect(@other_server).not_to receive(:get_relationship).with(42)
           expect {
             relationship = Relationship.load(@other_server, 42)
           }.to raise_error(ArgumentError)
@@ -74,7 +74,7 @@ module Neography
 
         it "can pass a relationship as the first argument, server as the second" do
           @other_server = Neography::Rest.new
-          @other_server.should_receive(:get_relationship).with(42)
+          expect(@other_server).to receive(:get_relationship).with(42)
           relationship = Relationship.load(42, @other_server)
         end
 
@@ -84,13 +84,13 @@ module Neography
     describe "#del" do
 
       before do
-        db.stub(:create_relationship) { relationship_hash }
+        allow(db).to receive(:create_relationship) { relationship_hash }
       end
 
       subject(:relationship) { Relationship.create("type", from, to, props) }
 
       it "deletes a node" do
-        db.should_receive(:delete_relationship).with("0")
+        expect(db).to receive(:delete_relationship).with("0")
         relationship.del
       end
 
@@ -99,17 +99,17 @@ module Neography
     describe "#other_node" do
 
       before do
-        db.stub(:create_relationship) { relationship_hash }
+        allow(db).to receive(:create_relationship) { relationship_hash }
       end
 
       subject(:relationship) { Relationship.create("type", from, to, props) }
 
       it "knows the other node based on from" do
-        relationship.other_node(from).should == to
+        expect(relationship.other_node(from)).to eq(to)
       end
 
       it "knows the other node based on to" do
-        relationship.other_node(to).should == from
+        expect(relationship.other_node(to)).to eq(from)
       end
 
     end

--- a/spec/unit/rest/batch_spec.rb
+++ b/spec/unit/rest/batch_spec.rb
@@ -12,7 +12,7 @@ module Neography
           { "id" => 1, "method" => "GET", "to" => "/node/bar" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:get_node, "foo"], [:get_node, "bar"]
       end
 
@@ -22,7 +22,7 @@ module Neography
           { "id" => 1, "method" => "GET", "to" => "/node/bar" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch ["get_node", "foo"], [:get_node, "bar"]
       end
       
@@ -32,7 +32,7 @@ module Neography
           { "id" => 1, "method" => "POST", "to" => "/node", "body" => { "baz" => "qux" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:create_node, { "foo" => "bar" }], [:create_node, { "baz" => "qux" }]
       end
 
@@ -42,7 +42,7 @@ module Neography
           { "id" => 1, "method" => "DELETE", "to" => "/node/bar" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:delete_node, "foo"], [:delete_node, "bar"]
       end
 
@@ -52,7 +52,7 @@ module Neography
           { "id" => 1, "method" => "POST", "to" => "/index/node/quux?unique", "body" => { "key" => "corge", "value" => "grault", "properties" => "garply" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:create_unique_node, "foo", "bar", "baz", "qux" ],
                         [:create_unique_node, "quux", "corge", "grault", "garply"]
       end
@@ -63,7 +63,7 @@ module Neography
           { "id" => 1, "method" => "POST", "to" => "/index/node/quux", "body" => { "uri" => "{0}", "key" => "corge", "value" => "grault" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:add_node_to_index, "foo", "bar", "baz", "qux" ],
                         [:add_node_to_index, "quux", "corge", "grault", "{0}"]
       end
@@ -74,7 +74,7 @@ module Neography
           { "id" => 1, "method" => "GET", "to" => "/index/node/qux/quux/corge" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:get_node_index, "foo", "bar", "baz" ],
                         [:get_node_index, "qux", "quux", "corge" ]
       end
@@ -86,7 +86,7 @@ module Neography
           { "id" => 2, "method" => "DELETE", "to" => "/index/node/index3/key3/value3/id3" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:remove_node_from_index, "index1", "id1", ],
                         [:remove_node_from_index, "index2", "key2", "id2" ],
                         [:remove_node_from_index, "index3", "key3", "value3", "id3" ]
@@ -98,7 +98,7 @@ module Neography
           { "id" => 1, "method" => "PUT", "to" => "/node/index2/properties/key2", "body" => "value2" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:set_node_property, "index1", { "key1" => "value1" } ],
                         [:set_node_property, "index2", { "key2" => "value2" } ]
       end
@@ -109,7 +109,7 @@ module Neography
           { "id" => 1, "method" => "PUT", "to" => "/node/index2/properties", "body" => { "key2" => "value2" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:reset_node_properties, "index1", { "key1" => "value1" } ],
                         [:reset_node_properties, "index2", { "key2" => "value2" } ]
       end
@@ -119,7 +119,7 @@ module Neography
           { "id" => 0, "method" => "POST", "to" => "{0}/labels", "body" => "foo" },
           { "id" => 1, "method" => "POST", "to" => "{0}/labels", "body" => "bar" },
         ]
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:add_label, "{0}", "foo"],
                         [:add_label, "{0}", "bar"]
       end
@@ -130,7 +130,7 @@ module Neography
           { "id" => 1, "method" => "GET", "to" => "/node/id2/relationships/all" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:get_node_relationships, "id1", "direction1" ],
                         [:get_node_relationships, "id2" ]
       end
@@ -141,7 +141,7 @@ module Neography
           { "id" => 1, "method" => "GET", "to" => "/relationship/bar" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:get_relationship, "foo"], [:get_relationship, "bar"]
       end
 
@@ -151,7 +151,7 @@ module Neography
           { "id" => 1, "method" => "POST", "to" => "{0}/relationships", "body" => { "to" => "{1}", "type" => "type2", "data" => "data2" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:create_relationship, "type1", "from1", "to1", "data1" ],
                         [:create_relationship, "type2", "{0}", "{1}", "data2" ]
       end
@@ -162,7 +162,7 @@ module Neography
           { "id" => 1, "method" => "DELETE", "to" => "/relationship/bar" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:delete_relationship, "foo"], [:delete_relationship, "bar"]
       end
 
@@ -172,7 +172,7 @@ module Neography
           { "id" => 1, "method" => "POST", "to" => "/index/relationship/index2?unique", "body" => { "key" => "key2", "value" => "value2", "type" => "type2", "start" => "{0}", "end" => "{1}", "properties" => "properties" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:create_unique_relationship, "index1", "key1", "value1", "type1", "node1", "node2","properties"  ],
                         [:create_unique_relationship, "index2", "key2", "value2", "type2", "{0}", "{1}", "properties" ]
       end
@@ -183,7 +183,7 @@ module Neography
           { "id" => 1, "method" => "POST", "to" => "/index/relationship/index2", "body" => { "uri" => "{0}", "key" => "key2", "value" => "value2" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:add_relationship_to_index, "index1", "key1", "value1", "rel1" ],
                         [:add_relationship_to_index, "index2", "key2", "value2", "{0}"]
       end
@@ -194,7 +194,7 @@ module Neography
           { "id" => 1, "method" => "GET", "to" => "/index/relationship/qux/quux/corge" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:get_relationship_index, "foo", "bar", "baz" ],
                         [:get_relationship_index, "qux", "quux", "corge" ]
       end
@@ -206,7 +206,7 @@ module Neography
           { "id" => 2, "method" => "DELETE", "to" => "/index/relationship/index3/key3/value3/id3" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:remove_relationship_from_index, "index1", "id1", ],
                         [:remove_relationship_from_index, "index2", "key2", "id2" ],
                         [:remove_relationship_from_index, "index3", "key3", "value3", "id3" ]
@@ -218,7 +218,7 @@ module Neography
           { "id" => 1, "method" => "PUT", "to" => "/relationship/index2/properties/key2", "body" => "value2" }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:set_relationship_property, "index1", { "key1" => "value1" } ],
                         [:set_relationship_property, "index2", { "key2" => "value2" } ]
       end
@@ -229,7 +229,7 @@ module Neography
           { "id" => 1, "method" => "PUT", "to" => "{0}/properties", "body" => { "key2" => "value2" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:reset_relationship_properties, "index1", { "key1" => "value1" } ],
                         [:reset_relationship_properties, "{0}", { "key2" => "value2" } ]
       end
@@ -240,7 +240,7 @@ module Neography
           { "id" => 1, "method" => "POST", "to" => "/ext/GremlinPlugin/graphdb/execute_script", "body" => { "script" => "script2", "params" => "params2" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:execute_script, "script1", "params1"],
                         [:execute_script, "script2", "params2"]
       end
@@ -251,7 +251,7 @@ module Neography
           { "id" => 1, "method" => "POST", "to" => "/cypher", "body" => { "query" => "query2" } }
         ]
 
-        subject.connection.should_receive(:post).with("/batch", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/batch", json_match(:body, expected_body))
         subject.batch [:execute_query, "query1", "params1"],
                         [:execute_query, "query2" ]
       end

--- a/spec/unit/rest/clean_spec.rb
+++ b/spec/unit/rest/clean_spec.rb
@@ -7,7 +7,7 @@ module Neography
       subject { Neography::Rest.new }
 
       it "cleans the database" do
-        subject.connection.should_receive(:delete).with("/cleandb/secret-key")
+        expect(subject.connection).to receive(:delete).with("/cleandb/secret-key")
         subject.clean_database("yes_i_really_want_to_clean_the_database")
       end
 

--- a/spec/unit/rest/constraints_spec.rb
+++ b/spec/unit/rest/constraints_spec.rb
@@ -7,12 +7,12 @@ module Neography
       subject { Neography::Rest.new }
 
       it "list constraints" do
-        subject.connection.should_receive(:get).with("/schema/constraint/")
+        expect(subject.connection).to receive(:get).with("/schema/constraint/")
         subject.get_constraints
       end
 
       it "get constraints for a label" do
-        subject.connection.should_receive(:get).with("/schema/constraint/label")
+        expect(subject.connection).to receive(:get).with("/schema/constraint/label")
         subject.get_constraints("label")
       end
 
@@ -21,22 +21,22 @@ module Neography
             :body    => '{"property_keys":["property"]}',
             :headers => json_content_type
           }
-        subject.connection.should_receive(:post).with("/schema/constraint/label/uniqueness/", options)
+        expect(subject.connection).to receive(:post).with("/schema/constraint/label/uniqueness/", options)
         subject.create_unique_constraint("label", "property")
       end
       
       it "get unique constraints for a label" do
-        subject.connection.should_receive(:get).with("/schema/constraint/label/uniqueness/")
+        expect(subject.connection).to receive(:get).with("/schema/constraint/label/uniqueness/")
         subject.get_uniqueness("label")
       end
 
       it "get a specific unique constraint for a label" do
-        subject.connection.should_receive(:get).with("/schema/constraint/label/uniqueness/property")
+        expect(subject.connection).to receive(:get).with("/schema/constraint/label/uniqueness/property")
         subject.get_unique_constraint("label", "property")
       end
       
       it "can delete a constraint for a label" do
-        subject.connection.should_receive(:delete).with("/schema/constraint/label/uniqueness/property")
+        expect(subject.connection).to receive(:delete).with("/schema/constraint/label/uniqueness/property")
         subject.drop_constraint("label","property")
       end
       

--- a/spec/unit/rest/cypher_spec.rb
+++ b/spec/unit/rest/cypher_spec.rb
@@ -11,7 +11,7 @@ module Neography
           :body=>"{\"query\":\"SOME QUERY\",\"params\":{\"foo\":\"bar\",\"baz\":\"qux\"}}",
           :headers=>{"Content-Type"=>"application/json", "Accept"=>"application/json;stream=true;charset=UTF-8"}
         }
-        subject.connection.should_receive(:post).with("/cypher", options)
+        expect(subject.connection).to receive(:post).with("/cypher", options)
         subject.execute_query("SOME QUERY", { :foo => "bar", :baz => "qux" })
       end
 

--- a/spec/unit/rest/extensions_spec.rb
+++ b/spec/unit/rest/extensions_spec.rb
@@ -9,7 +9,7 @@ module Neography
       it "executes an extensions get query" do
         path = "/unmanaged_extension/test"
 
-        subject.connection.should_receive(:get).with(path)
+        expect(subject.connection).to receive(:get).with(path)
         subject.get_extension("/unmanaged_extension/test")
       end
 
@@ -19,7 +19,7 @@ module Neography
           :body=>"{\"foo\":\"bar\",\"baz\":\"qux\"}",
           :headers=>{"Content-Type"=>"application/json", "Accept"=>"application/json;stream=true"}
         }
-        subject.connection.should_receive(:post).with(path, options)
+        expect(subject.connection).to receive(:post).with(path, options)
         subject.post_extension("/unmanaged_extension/test", { :foo => "bar", :baz => "qux" })
       end
 

--- a/spec/unit/rest/gremlin_spec.rb
+++ b/spec/unit/rest/gremlin_spec.rb
@@ -11,13 +11,13 @@ module Neography
           :body=>"{\"script\":\"SOME SCRIPT\",\"params\":{\"foo\":\"bar\",\"baz\":\"qux\"}}",
           :headers=>{"Content-Type"=>"application/json"}
         }
-        subject.connection.should_receive(:post).with("/ext/GremlinPlugin/graphdb/execute_script", options)
+        expect(subject.connection).to receive(:post).with("/ext/GremlinPlugin/graphdb/execute_script", options)
         subject.execute_script("SOME SCRIPT", { :foo => "bar", :baz => "qux" })
       end
 
       it "returns nil if script result is null" do
-        subject.connection.stub(:post).and_return("null")
-        subject.execute_script("", {}).should be_nil
+        allow(subject.connection).to receive(:post).and_return("null")
+        expect(subject.execute_script("", {})).to be_nil
       end
 
     end

--- a/spec/unit/rest/helpers_spec.rb
+++ b/spec/unit/rest/helpers_spec.rb
@@ -10,18 +10,18 @@ module Neography
 
         [ :incoming, "incoming", :in, "in" ].each do |direction|
           it "parses 'in' direction" do
-            subject.parse_direction(direction).should == "in"
+            expect(subject.parse_direction(direction)).to eq("in")
           end
         end
 
         [ :outgoing, "outgoing", :out, "out" ].each do |direction|
           it "parses 'out' direction" do
-            subject.parse_direction(direction).should == "out"
+            expect(subject.parse_direction(direction)).to eq("out")
           end
         end
 
         it "parses 'all' direction by default" do
-          subject.parse_direction("foo").should == "all"
+          expect(subject.parse_direction("foo")).to eq("all")
         end
 
       end
@@ -32,88 +32,88 @@ context "options" do
         context "order" do
           [ :breadth, "breadth", "breadth first", "breadthFirst", :wide, "wide" ].each do |order|
             it "parses breadth first" do
-              subject.send(:parse_order, order).should == "breadth first"
+              expect(subject.send(:parse_order, order)).to eq("breadth first")
             end
           end
 
           it "parses depth first by default" do
-            subject.send(:parse_order, "foo").should == "depth first"
+            expect(subject.send(:parse_order, "foo")).to eq("depth first")
           end
         end
 
         context "uniqueness" do
           [ :nodeglobal, "node global", "nodeglobal", "node_global" ].each do |order|
             it "parses node global" do
-              subject.send(:parse_uniqueness, order).should == "node global"
+              expect(subject.send(:parse_uniqueness, order)).to eq("node global")
             end
           end
 
           [ :nodepath, "node path", "nodepath", "node_path" ].each do |order|
             it "parses node path" do
-              subject.send(:parse_uniqueness, order).should == "node path"
+              expect(subject.send(:parse_uniqueness, order)).to eq("node path")
             end
           end
 
           [ :noderecent, "node recent", "noderecent", "node_recent" ].each do |order|
             it "parses node recent" do
-              subject.send(:parse_uniqueness, order).should == "node recent"
+              expect(subject.send(:parse_uniqueness, order)).to eq("node recent")
             end
           end
 
           [ :relationshipglobal, "relationship global", "relationshipglobal", "relationship_global" ].each do |order|
             it "parses relationship global" do
-              subject.send(:parse_uniqueness, order).should == "relationship global"
+              expect(subject.send(:parse_uniqueness, order)).to eq("relationship global")
             end
           end
 
           [ :relationshippath, "relationship path", "relationshippath", "relationship_path" ].each do |order|
             it "parses relationship path" do
-              subject.send(:parse_uniqueness, order).should == "relationship path"
+              expect(subject.send(:parse_uniqueness, order)).to eq("relationship path")
             end
           end
 
           [ :relationshiprecent, "relationship recent", "relationshiprecent", "relationship_recent" ].each do |order|
             it "parses relationship recent" do
-              subject.send(:parse_uniqueness, order).should == "relationship recent"
+              expect(subject.send(:parse_uniqueness, order)).to eq("relationship recent")
             end
           end
 
           it "parses none by default" do
-            subject.send(:parse_uniqueness, "foo").should == "none"
+            expect(subject.send(:parse_uniqueness, "foo")).to eq("none")
           end
         end
 
         context "depth" do
           it "parses nil as nil" do
-            subject.send(:parse_depth, nil).should be_nil
+            expect(subject.send(:parse_depth, nil)).to be_nil
           end
           it "parses 0 as 1" do
-            subject.send(:parse_depth, "0").should == 1
+            expect(subject.send(:parse_depth, "0")).to eq(1)
           end
           it "parses integers" do
-            subject.send(:parse_depth, "42").should == 42
+            expect(subject.send(:parse_depth, "42")).to eq(42)
           end
         end
 
         context "type" do
           [ :relationship, "relationship", :relationships, "relationships" ].each do |type|
             it "parses relationship" do
-              subject.send(:parse_type, type).should == "relationship"
+              expect(subject.send(:parse_type, type)).to eq("relationship")
             end
           end
           [ :path, "path", :paths, "paths" ].each do |type|
             it "parses path" do
-              subject.send(:parse_type, type).should == "path"
+              expect(subject.send(:parse_type, type)).to eq("path")
             end
           end
           [ :fullpath, "fullpath", :fullpaths, "fullpaths" ].each do |type|
             it "parses fullpath" do
-              subject.send(:parse_type, type).should == "fullpath"
+              expect(subject.send(:parse_type, type)).to eq("fullpath")
             end
           end
 
           it "parses node by default" do
-            subject.send(:parse_type, "foo").should == "node"
+            expect(subject.send(:parse_type, "foo")).to eq("node")
           end
         end
       end      

--- a/spec/unit/rest/labels_spec.rb
+++ b/spec/unit/rest/labels_spec.rb
@@ -7,27 +7,27 @@ module Neography
       subject { Neography::Rest.new }
 
       it "list node labels" do
-        subject.connection.should_receive(:get).with("/labels")
+        expect(subject.connection).to receive(:get).with("/labels")
         subject.list_labels
       end
 
       it "get labels for node" do
-        subject.connection.should_receive(:get).with("/node/0/labels")
+        expect(subject.connection).to receive(:get).with("/node/0/labels")
         subject.get_node_labels(0)
       end
 
       it "get nodes for labels" do
-        subject.connection.should_receive(:get).with("/label/person/nodes")
+        expect(subject.connection).to receive(:get).with("/label/person/nodes")
         subject.get_nodes_labeled("person")
       end
 
       it "find nodes for labels and property string" do
-        subject.connection.should_receive(:get).with("/label/person/nodes?name=%22max%22")
+        expect(subject.connection).to receive(:get).with("/label/person/nodes?name=%22max%22")
         subject.find_nodes_labeled("person", {:name => "max"})
       end
 
       it "find nodes for labels and property integer" do
-        subject.connection.should_receive(:get).with("/label/person/nodes?age=26")
+        expect(subject.connection).to receive(:get).with("/label/person/nodes?age=26")
         subject.find_nodes_labeled("person", {:age => 26})
       end
 
@@ -36,7 +36,7 @@ module Neography
           :body    => '["Actor"]',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:post).with("/node/0/labels", options)
+        expect(subject.connection).to receive(:post).with("/node/0/labels", options)
         subject.add_label(0, ["Actor"])
       end
 
@@ -45,7 +45,7 @@ module Neography
           :body    => '["Actor","Director"]',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:post).with("/node/0/labels", options)
+        expect(subject.connection).to receive(:post).with("/node/0/labels", options)
         subject.add_label(0, ["Actor", "Director"])
       end
 
@@ -54,7 +54,7 @@ module Neography
           :body    => '["Actor"]',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:put).with("/node/0/labels", options)
+        expect(subject.connection).to receive(:put).with("/node/0/labels", options)
         subject.set_label(0, ["Actor"])
       end
 
@@ -63,12 +63,12 @@ module Neography
           :body    => '["Actor","Director"]',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:put).with("/node/0/labels", options)
+        expect(subject.connection).to receive(:put).with("/node/0/labels", options)
         subject.set_label(0, ["Actor", "Director"])
       end
       
       it "can delete a label from a node" do
-        subject.connection.should_receive(:delete).with("/node/0/labels/Actor")
+        expect(subject.connection).to receive(:delete).with("/node/0/labels/Actor")
         subject.delete_label(0,"Actor")
       end
       

--- a/spec/unit/rest/node_auto_indexes_spec.rb
+++ b/spec/unit/rest/node_auto_indexes_spec.rb
@@ -7,61 +7,61 @@ module Neography
       subject { Neography::Rest.new }
 
       it "gets a node from an auto index" do
-        subject.connection.should_receive(:get).with("/index/auto/node/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/auto/node/some_key/some_value")
         subject.get_node_auto_index("some_key", "some_value")
       end
 
       it "returns nil if nothing was found in the auto index" do
-        subject.connection.stub(:get).and_return(nil)
-        subject.get_node_auto_index("some_key", "some_value").should be_nil
+        allow(subject.connection).to receive(:get).and_return(nil)
+        expect(subject.get_node_auto_index("some_key", "some_value")).to be_nil
       end
 
       it "finds by key and value if value passed to #find_or_query" do
-        subject.connection.should_receive(:get).with("/index/auto/node/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/auto/node/some_key/some_value")
         subject.find_node_auto_index("some_key", "some_value")
       end
 
       it "finds by query if no value passed to #find_or_query" do
-        subject.connection.should_receive(:get).with("/index/auto/node/?query=some_query")
+        expect(subject.connection).to receive(:get).with("/index/auto/node/?query=some_query")
         subject.find_node_auto_index("some_query")
 
         query = "some_query AND another_one"
-        subject.connection.should_receive(:get).with("/index/auto/node/?query=#{URI.encode(query)}")
+        expect(subject.connection).to receive(:get).with("/index/auto/node/?query=#{URI.encode(query)}")
         subject.find_node_auto_index(query)
       end
 
       it "finds by key and value" do
-        subject.connection.should_receive(:get).with("/index/auto/node/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/auto/node/some_key/some_value")
         subject.find_node_auto_index("some_key", "some_value")
       end
 
       it "finds by query" do
-        subject.connection.should_receive(:get).with("/index/auto/node/?query=some_query")
+        expect(subject.connection).to receive(:get).with("/index/auto/node/?query=some_query")
         subject.find_node_auto_index("some_query")
       end
 
       it "gets the status" do
-        subject.connection.should_receive(:get).with("/index/auto/node/status")
+        expect(subject.connection).to receive(:get).with("/index/auto/node/status")
         subject.get_node_auto_index_status
       end
 
       it "sets the status" do
-        subject.connection.should_receive(:put).with("/index/auto/node/status", hash_match(:body, '"foo"'))
+        expect(subject.connection).to receive(:put).with("/index/auto/node/status", hash_match(:body, '"foo"'))
         subject.set_node_auto_index_status("foo")
       end
 
       it "gets auto index properties" do
-        subject.connection.should_receive(:get).with("/index/auto/node/properties")
+        expect(subject.connection).to receive(:get).with("/index/auto/node/properties")
         subject.get_node_auto_index_properties
       end
 
       it "adds a property to an auto index" do
-        subject.connection.should_receive(:post).with("/index/auto/node/properties", hash_match(:body, "foo"))
+        expect(subject.connection).to receive(:post).with("/index/auto/node/properties", hash_match(:body, "foo"))
         subject.add_node_auto_index_property("foo")
       end
 
       it "removes a property from an auto index" do
-        subject.connection.should_receive(:delete).with("/index/auto/node/properties/foo")
+        expect(subject.connection).to receive(:delete).with("/index/auto/node/properties/foo")
         subject.remove_node_auto_index_property("foo")
       end
 

--- a/spec/unit/rest/node_indexes_spec.rb
+++ b/spec/unit/rest/node_indexes_spec.rb
@@ -7,7 +7,7 @@ module Neography
       subject { Neography::Rest.new }
 
       it "lists all indexes" do
-        subject.connection.should_receive(:get).with("/index/node")
+        expect(subject.connection).to receive(:get).with("/index/node")
         subject.list_node_indexes
       end
 
@@ -19,13 +19,13 @@ module Neography
           },
           "name" => "some_index"
         }
-        subject.connection.should_receive(:post).with("/index/node", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/index/node", json_match(:body, expected_body))
         subject.create_node_index("some_index", "some_type", "some_provider")
       end
 
       it "returns the post result after creation" do
-        subject.connection.stub(:post).and_return("foo")
-        subject.create_node_index("some_index", "some_type", "some_provider").should == "foo"
+        allow(subject.connection).to receive(:post).and_return("foo")
+        expect(subject.create_node_index("some_index", "some_type", "some_provider")).to eq("foo")
       end
 
       it "creates an auto-index" do
@@ -36,7 +36,7 @@ module Neography
           },
           "name" => "node_auto_index"
         }
-        subject.connection.should_receive(:post).with("/index/node", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/index/node", json_match(:body, expected_body))
         subject.create_node_auto_index("some_type", "some_provider")
       end
 
@@ -46,7 +46,7 @@ module Neography
           "key" => "key",
           "value" => "value"
         }
-        subject.connection.should_receive(:post).with("/index/node/some_index?unique", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/index/node/some_index?unique", json_match(:body, expected_body))
         subject.create_unique_node("some_index", "key", "value", "properties")
       end
 
@@ -56,7 +56,7 @@ module Neography
           "key" => "key",
           "value" => "value"
         }
-        subject.connection.should_receive(:post).with("/index/node/some_index?uniqueness=get_or_create", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/index/node/some_index?uniqueness=get_or_create", json_match(:body, expected_body))
         subject.get_or_create_unique_node("some_index", "key", "value", "properties")
       end
 
@@ -66,72 +66,72 @@ module Neography
           "key" => "key",
           "value" => "value"
         }
-        subject.connection.should_receive(:post).with("/index/node/some_index", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/index/node/some_index", json_match(:body, expected_body))
         subject.add_node_to_index("some_index", "key", "value", "42")
       end
 
       it "gets a node from an index" do
-        subject.connection.should_receive(:get).with("/index/node/some_index/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/node/some_index/some_key/some_value")
         subject.get_node_index("some_index", "some_key", "some_value")
       end
 
       it "returns nil if nothing was found in the index" do
-        subject.connection.stub(:get).and_return(nil)
-        subject.get_node_index("some_index", "some_key", "some_value").should be_nil
+        allow(subject.connection).to receive(:get).and_return(nil)
+        expect(subject.get_node_index("some_index", "some_key", "some_value")).to be_nil
       end
 
       it "finds by key and value if both passed to #find" do
-        subject.connection.should_receive(:get).with("/index/node/some_index/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/node/some_index/some_key/some_value")
         subject.find_node_index("some_index", "some_key", "some_value")
       end
 
       it "finds by query if no value passed to #find" do
-        subject.connection.should_receive(:get).with("/index/node/some_index?query=some_query")
+        expect(subject.connection).to receive(:get).with("/index/node/some_index?query=some_query")
         subject.find_node_index("some_index", "some_query")
       end
 
       it "finds by key and value" do
-        subject.connection.should_receive(:get).with("/index/node/some_index/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/node/some_index/some_key/some_value")
         subject.find_node_index_by_key_value("some_index", "some_key", "some_value")
       end
 
       it "finds by query" do
-        subject.connection.should_receive(:get).with("/index/node/some_index?query=some_query")
+        expect(subject.connection).to receive(:get).with("/index/node/some_index?query=some_query")
         subject.find_node_index_by_query("some_index", "some_query")
       end
 
       it "removes a node from an index by id for #remove with two arguments" do
-        subject.connection.should_receive(:delete).with("/index/node/some_index/42")
+        expect(subject.connection).to receive(:delete).with("/index/node/some_index/42")
         subject.remove_node_from_index("some_index", "42")
       end
 
       it "removes a node from an index by key for #remove with three arguments" do
-        subject.connection.should_receive(:delete).with("/index/node/some_index/some_key/42")
+        expect(subject.connection).to receive(:delete).with("/index/node/some_index/some_key/42")
         subject.remove_node_from_index("some_index", "some_key", "42")
       end
 
       it "removes a node from an index by key and value for #remove with four arguments" do
-        subject.connection.should_receive(:delete).with("/index/node/some_index/some_key/some_value/42")
+        expect(subject.connection).to receive(:delete).with("/index/node/some_index/some_key/some_value/42")
         subject.remove_node_from_index("some_index", "some_key", "some_value", "42")
       end
 
       it "removes a node from an index" do
-        subject.connection.should_receive(:delete).with("/index/node/some_index/42")
+        expect(subject.connection).to receive(:delete).with("/index/node/some_index/42")
         subject.remove_node_index_by_id("some_index", "42")
       end
 
       it "removes a node from an index by key" do
-        subject.connection.should_receive(:delete).with("/index/node/some_index/some_key/42")
+        expect(subject.connection).to receive(:delete).with("/index/node/some_index/some_key/42")
         subject.remove_node_index_by_key("some_index", "42", "some_key")
       end
 
       it "removes a node from an index by key and value" do
-        subject.connection.should_receive(:delete).with("/index/node/some_index/some_key/some_value/42")
+        expect(subject.connection).to receive(:delete).with("/index/node/some_index/some_key/some_value/42")
         subject.remove_node_index_by_value("some_index", "42", "some_key", "some_value")
       end
 
       it "drops an index" do
-        subject.connection.should_receive(:delete).with("/index/node/some_index")
+        expect(subject.connection).to receive(:delete).with("/index/node/some_index")
         subject.drop_node_index("some_index")
       end
 

--- a/spec/unit/rest/node_paths_spec.rb
+++ b/spec/unit/rest/node_paths_spec.rb
@@ -14,7 +14,7 @@ module Neography
           "algorithm"     => "shortestPath"
         }
 
-        subject.connection.should_receive(:post).with("/node/42/path", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/node/42/path", json_match(:body, expected_body))
 
         subject.get_path("42", "43", "relationships", 3, "shortestPath")
       end
@@ -27,7 +27,7 @@ module Neography
           "algorithm"     => "shortestPath"
         }
 
-        subject.connection.should_receive(:post).with("/node/42/paths", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/node/42/paths", json_match(:body, expected_body))
 
         subject.get_paths("42", "43", "relationships", 3, "shortestPath")
       end
@@ -41,7 +41,7 @@ module Neography
           "algorithm"     => "shortestPath"
         }
 
-        subject.connection.should_receive(:post).with("/node/42/paths", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/node/42/paths", json_match(:body, expected_body))
 
         subject.get_shortest_weighted_path("42", "43", "relationships", "cost", 3, "shortestPath")
       end
@@ -50,24 +50,24 @@ module Neography
 
         [ :shortest, "shortest", :shortestPath, "shortestPath", :short, "short" ].each do |algorithm|
           it "parses shortestPath" do
-            subject.send(:get_algorithm, algorithm).should == "shortestPath"
+            expect(subject.send(:get_algorithm, algorithm)).to eq("shortestPath")
           end
         end
 
         [ :allSimplePaths, "allSimplePaths", :simple, "simple" ].each do |algorithm|
           it "parses allSimplePaths" do
-            subject.send(:get_algorithm, algorithm).should == "allSimplePaths"
+            expect(subject.send(:get_algorithm, algorithm)).to eq("allSimplePaths")
           end
         end
 
         [ :dijkstra, "dijkstra" ].each do |algorithm|
           it "parses dijkstra" do
-            subject.send(:get_algorithm, algorithm).should == "dijkstra"
+            expect(subject.send(:get_algorithm, algorithm)).to eq("dijkstra")
           end
         end
 
         it "parses allPaths by default" do
-          subject.send(:get_algorithm, "foo").should == "allPaths"
+          expect(subject.send(:get_algorithm, "foo")).to eq("allPaths")
         end
 
       end

--- a/spec/unit/rest/node_properties_spec.rb
+++ b/spec/unit/rest/node_properties_spec.rb
@@ -15,8 +15,8 @@ module Neography
           :body    => '"qux"',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:put).with("/node/42/properties/foo", options1)
-        subject.connection.should_receive(:put).with("/node/42/properties/baz", options2)
+        expect(subject.connection).to receive(:put).with("/node/42/properties/foo", options1)
+        expect(subject.connection).to receive(:put).with("/node/42/properties/baz", options2)
         subject.set_node_properties("42", {:foo => "bar", :baz => "qux"})
       end
 
@@ -25,36 +25,36 @@ module Neography
           :body    => '{"foo":"bar"}',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:put).with("/node/42/properties", options)
+        expect(subject.connection).to receive(:put).with("/node/42/properties", options)
         subject.reset_node_properties("42", {:foo => "bar"})
       end
 
       context "getting properties" do
 
         it "gets all properties" do
-          subject.connection.should_receive(:get).with("/node/42/properties")
+          expect(subject.connection).to receive(:get).with("/node/42/properties")
           subject.get_node_properties("42")
         end
 
         it "gets multiple properties" do
-          subject.connection.should_receive(:get).with("/node/42/properties/foo")
-          subject.connection.should_receive(:get).with("/node/42/properties/bar")
+          expect(subject.connection).to receive(:get).with("/node/42/properties/foo")
+          expect(subject.connection).to receive(:get).with("/node/42/properties/bar")
           subject.get_node_properties("42", "foo", "bar")
         end
 
         it "returns multiple properties as a hash" do
-          subject.connection.stub(:get).and_return("baz", "qux")
-          subject.get_node_properties("42", "foo", "bar").should == { "foo" => "baz", "bar" => "qux" }
+          allow(subject.connection).to receive(:get).and_return("baz", "qux")
+          expect(subject.get_node_properties("42", "foo", "bar")).to eq({ "foo" => "baz", "bar" => "qux" })
         end
 
         it "returns nil if no properties were found" do
-          subject.connection.stub(:get).and_return(nil, nil)
-          subject.get_node_properties("42", "foo", "bar").should be_nil
+          allow(subject.connection).to receive(:get).and_return(nil, nil)
+          expect(subject.get_node_properties("42", "foo", "bar")).to be_nil
         end
 
         it "returns hash without nil return values" do
-          subject.connection.stub(:get).and_return("baz", nil)
-          subject.get_node_properties("42", "foo", "bar").should == { "foo" => "baz" }
+          allow(subject.connection).to receive(:get).and_return("baz", nil)
+          expect(subject.get_node_properties("42", "foo", "bar")).to eq({ "foo" => "baz" })
         end
 
       end
@@ -62,13 +62,13 @@ module Neography
       context "removing properties" do
 
         it "removes all properties" do
-          subject.connection.should_receive(:delete).with("/node/42/properties")
+          expect(subject.connection).to receive(:delete).with("/node/42/properties")
           subject.remove_node_properties("42")
         end
 
         it "removes multiple properties" do
-          subject.connection.should_receive(:delete).with("/node/42/properties/foo")
-          subject.connection.should_receive(:delete).with("/node/42/properties/bar")
+          expect(subject.connection).to receive(:delete).with("/node/42/properties/foo")
+          expect(subject.connection).to receive(:delete).with("/node/42/properties/bar")
           subject.remove_node_properties("42", "foo", "bar")
         end
 

--- a/spec/unit/rest/node_relationships_spec.rb
+++ b/spec/unit/rest/node_relationships_spec.rb
@@ -11,44 +11,44 @@ module Neography
           "to" => "http://localhost:7474/node/43",
           "data" => {"foo"=>"bar","baz"=>"qux"}
         }
-        subject.connection.should_receive(:post).with("/node/42/relationships", json_match(:body, body_hash))
+        expect(subject.connection).to receive(:post).with("/node/42/relationships", json_match(:body, body_hash))
 
         subject.create_relationship("some_type", "42", "43", {:foo => "bar", :baz => "qux"})
       end
 
       it "returns the post results" do
-        subject.connection.stub(:post).and_return("foo")
+        allow(subject.connection).to receive(:post).and_return("foo")
 
-        subject.create_relationship("some_type", "42", "43", {}).should == "foo"
+        expect(subject.create_relationship("some_type", "42", "43", {})).to eq("foo")
       end
 
       it "gets relationships" do
-        subject.connection.should_receive(:get).with("/node/42/relationships/all")
+        expect(subject.connection).to receive(:get).with("/node/42/relationships/all")
         subject.get_node_relationships("42")
       end
 
       it "gets relationships with direction" do
-        subject.connection.should_receive(:get).with("/node/42/relationships/in")
+        expect(subject.connection).to receive(:get).with("/node/42/relationships/in")
         subject.get_node_relationships("42", :in)
       end
 
       it "gets relationships with direction and type" do
-        subject.connection.should_receive(:get).with("/node/42/relationships/in/foo")
+        expect(subject.connection).to receive(:get).with("/node/42/relationships/in/foo")
         subject.get_node_relationships("42", :in, "foo")
       end
 
       it "gets relationships with direction and types" do
-        subject.connection.should_receive(:get).with("/node/42/relationships/in/foo%26bar")
+        expect(subject.connection).to receive(:get).with("/node/42/relationships/in/foo%26bar")
         subject.get_node_relationships("42", :in, ["foo", "bar"])
       end
 
       it "returns empty array if no relationships were found" do
-        subject.connection.stub(:get).and_return([])
-        subject.get_node_relationships("42", :in).should be_empty
+        allow(subject.connection).to receive(:get).and_return([])
+        expect(subject.get_node_relationships("42", :in)).to be_empty
       end
 
       it "returns empty array if no relationships were found by type" do
-        subject.connection.stub(:get).and_return([])
+        allow(subject.connection).to receive(:get).and_return([])
         subject.get_node_relationships("42", :in, "foo")
       end
 

--- a/spec/unit/rest/node_traversal_spec.rb
+++ b/spec/unit/rest/node_traversal_spec.rb
@@ -25,7 +25,7 @@ module Neography
           "max_depth"       => 4
         }
 
-        subject.connection.should_receive(:post).with("/node/42/traverse/relationship", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/node/42/traverse/relationship", json_match(:body, expected_body))
 
         subject.traverse("42", :relationship, description)
       end      

--- a/spec/unit/rest/nodes_spec.rb
+++ b/spec/unit/rest/nodes_spec.rb
@@ -8,30 +8,30 @@ module Neography
 
       context "get nodes" do
         it "gets single nodes" do
-          subject.connection.should_receive(:get).with("/node/42")
+          expect(subject.connection).to receive(:get).with("/node/42")
           subject.get_node("42")
         end
 
         it "gets multiple nodes" do
-          subject.connection.should_receive(:get).with("/node/42")
-          subject.connection.should_receive(:get).with("/node/43")
+          expect(subject.connection).to receive(:get).with("/node/42")
+          expect(subject.connection).to receive(:get).with("/node/43")
           subject.get_nodes("42", "43")
         end
 
         it "returns multiple nodes in an array" do
-          subject.connection.stub(:get).and_return("foo", "bar")
-          subject.get_nodes("42", "43").should == [ "foo", "bar" ]
+          allow(subject.connection).to receive(:get).and_return("foo", "bar")
+          expect(subject.get_nodes("42", "43")).to eq([ "foo", "bar" ])
         end
 
         it "gets the root node" do
-          subject.connection.stub(:get).with("/").and_return({ "reference_node" => "42" })
-          subject.connection.should_receive(:get).with("/node/42")
+          allow(subject.connection).to receive(:get).with("/").and_return({ "reference_node" => "42" })
+          expect(subject.connection).to receive(:get).with("/node/42")
           subject.get_root
         end
 
         it "returns the root node" do
-          subject.connection.stub(:get).and_return({ "reference_node" => "42" }, "foo")
-          subject.get_root.should == "foo"
+          allow(subject.connection).to receive(:get).and_return({ "reference_node" => "42" }, "foo")
+          expect(subject.get_root).to eq("foo")
         end
       end
 
@@ -42,13 +42,13 @@ module Neography
             :body    => '{"foo":"bar","baz":"qux"}',
             :headers => json_content_type
           }
-          subject.connection.should_receive(:post).with("/node", options)
+          expect(subject.connection).to receive(:post).with("/node", options)
           subject.create_node_with_attributes({:foo => "bar", :baz => "qux"})
         end
 
         it "returns the created node" do
-          subject.connection.stub(:post).and_return("foo")
-          subject.create_node_with_attributes({}).should == "foo"
+          allow(subject.connection).to receive(:post).and_return("foo")
+          expect(subject.create_node_with_attributes({})).to eq("foo")
         end
 
         it "creates with attributes using #create method" do
@@ -56,22 +56,22 @@ module Neography
             :body    => '{"foo":"bar","baz":"qux"}',
             :headers => json_content_type
           }
-          subject.connection.should_receive(:post).with("/node", options)
+          expect(subject.connection).to receive(:post).with("/node", options)
           subject.create_node({:foo => "bar", :baz => "qux"})
         end
 
         it "creates empty nodes" do
-          subject.connection.should_receive(:post).with("/node")
+          expect(subject.connection).to receive(:post).with("/node")
           subject.create_empty_node
         end
 
         it "returns an empty node" do
-          subject.connection.stub(:post).and_return("foo")
-          subject.create_empty_node.should == "foo"
+          allow(subject.connection).to receive(:post).and_return("foo")
+          expect(subject.create_empty_node).to eq("foo")
         end
 
         it "creates empty nodes using #create method" do
-          subject.connection.should_receive(:post).with("/node")
+          expect(subject.connection).to receive(:post).with("/node")
           subject.create_node
         end
 
@@ -80,7 +80,7 @@ module Neography
       context "delete nodes" do
 
         it "deletes a node" do
-          subject.connection.should_receive(:delete).with("/node/42")
+          expect(subject.connection).to receive(:delete).with("/node/42")
           subject.delete_node("42")
         end
 
@@ -97,8 +97,8 @@ module Neography
             :body    => '{"foo2":"bar2","baz2":"qux2"}',
             :headers => json_content_type
           }
-          subject.connection.should_receive(:post).with("/node", options1)
-          subject.connection.should_receive(:post).with("/node", options2)
+          expect(subject.connection).to receive(:post).with("/node", options1)
+          expect(subject.connection).to receive(:post).with("/node", options2)
 
           subject.create_nodes([
             {:foo1 => "bar1", :baz1 => "qux1"},
@@ -107,8 +107,8 @@ module Neography
         end
 
         it "returns multiple nodes with attributes in an array" do
-          subject.connection.stub(:post).and_return("foo", "bar")
-          subject.create_nodes([{},{}]).should == ["foo", "bar"]
+          allow(subject.connection).to receive(:post).and_return("foo", "bar")
+          expect(subject.create_nodes([{},{}])).to eq(["foo", "bar"])
         end
 
         # exotic?
@@ -117,8 +117,8 @@ module Neography
             :body    => '{"foo1":"bar1","baz1":"qux1"}',
             :headers => json_content_type
           }
-          subject.connection.should_receive(:post).with("/node", options1)
-          subject.connection.should_receive(:post).with("/node")
+          expect(subject.connection).to receive(:post).with("/node", options1)
+          expect(subject.connection).to receive(:post).with("/node")
 
           subject.create_nodes([
             {:foo1 => "bar1", :baz1 => "qux1"},
@@ -127,13 +127,13 @@ module Neography
         end
 
         it "creates multiple empty nodes" do
-          subject.connection.should_receive(:post).with("/node").twice
+          expect(subject.connection).to receive(:post).with("/node").twice
           subject.create_nodes(2)
         end
 
         it "returns multiple empty nodes in an array" do
-          subject.connection.stub(:post).and_return("foo", "bar")
-          subject.create_nodes(2).should == ["foo", "bar"]
+          allow(subject.connection).to receive(:post).and_return("foo", "bar")
+          expect(subject.create_nodes(2)).to eq(["foo", "bar"])
         end
 
       end
@@ -151,8 +151,8 @@ module Neography
             :body    => '{"foo2":"bar2","baz2":"qux2"}',
             :headers => json_content_type
           }
-          subject.connection.should_receive(:post).with("/node", options1)
-          subject.connection.should_receive(:post).with("/node", options2)
+          expect(subject.connection).to receive(:post).with("/node", options1)
+          expect(subject.connection).to receive(:post).with("/node", options2)
 
           subject.create_nodes_threaded([
             {:foo1 => "bar1", :baz1 => "qux1"},
@@ -166,8 +166,8 @@ module Neography
             :body    => '{"foo1":"bar1","baz1":"qux1"}',
             :headers => json_content_type
           }
-          subject.connection.should_receive(:post).with("/node", options1)
-          subject.connection.should_receive(:post).with("/node")
+          expect(subject.connection).to receive(:post).with("/node", options1)
+          expect(subject.connection).to receive(:post).with("/node")
 
           subject.create_nodes_threaded([
             {:foo1 => "bar1", :baz1 => "qux1"},
@@ -176,7 +176,7 @@ module Neography
         end
 
         it "creates multiple empty nodes" do
-          subject.connection.should_receive(:post).with("/node").twice
+          expect(subject.connection).to receive(:post).with("/node").twice
           subject.create_nodes_threaded(2)
         end
 

--- a/spec/unit/rest/relationship_auto_indexes_spec.rb
+++ b/spec/unit/rest/relationship_auto_indexes_spec.rb
@@ -7,57 +7,57 @@ module Neography
       subject { Neography::Rest.new }
 
       it "gets a relationship from an auto index" do
-        subject.connection.should_receive(:get).with("/index/auto/relationship/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/auto/relationship/some_key/some_value")
         subject.get_relationship_auto_index("some_key", "some_value")
       end
 
       it "returns nil if nothing was found in the auto index" do
-        subject.connection.stub(:get).and_return(nil)
-        subject.get_relationship_auto_index("some_key", "some_value").should be_nil
+        allow(subject.connection).to receive(:get).and_return(nil)
+        expect(subject.get_relationship_auto_index("some_key", "some_value")).to be_nil
       end
 
       it "finds by key and value if value passed to #find_or_query" do
-        subject.connection.should_receive(:get).with("/index/auto/relationship/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/auto/relationship/some_key/some_value")
         subject.find_relationship_auto_index("some_key", "some_value")
       end
 
       it "finds by query if no value passed to #find_or_query" do
-        subject.connection.should_receive(:get).with("/index/auto/relationship/?query=some_query")
+        expect(subject.connection).to receive(:get).with("/index/auto/relationship/?query=some_query")
         subject.find_relationship_auto_index("some_query")
       end
 
       it "finds by key and value" do
-        subject.connection.should_receive(:get).with("/index/auto/relationship/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/auto/relationship/some_key/some_value")
         subject.find_relationship_auto_index("some_key", "some_value")
       end
 
       it "finds by query" do
-        subject.connection.should_receive(:get).with("/index/auto/relationship/?query=some_query")
+        expect(subject.connection).to receive(:get).with("/index/auto/relationship/?query=some_query")
         subject.find_relationship_auto_index("some_query")
       end
 
       it "gets the status" do
-        subject.connection.should_receive(:get).with("/index/auto/relationship/status")
+        expect(subject.connection).to receive(:get).with("/index/auto/relationship/status")
         subject.get_relationship_auto_index_status
       end
 
       it "sets the status" do
-        subject.connection.should_receive(:put).with("/index/auto/relationship/status", hash_match(:body, '"foo"'))
+        expect(subject.connection).to receive(:put).with("/index/auto/relationship/status", hash_match(:body, '"foo"'))
         subject.set_relationship_auto_index_status("foo")
       end
 
       it "gets auto index properties" do
-        subject.connection.should_receive(:get).with("/index/auto/relationship/properties")
+        expect(subject.connection).to receive(:get).with("/index/auto/relationship/properties")
         subject.get_relationship_auto_index_properties
       end
 
       it "adds a property to an auto index" do
-        subject.connection.should_receive(:post).with("/index/auto/relationship/properties", hash_match(:body, "foo"))
+        expect(subject.connection).to receive(:post).with("/index/auto/relationship/properties", hash_match(:body, "foo"))
         subject.add_relationship_auto_index_property("foo")
       end
 
       it "removes a property from an auto index" do
-        subject.connection.should_receive(:delete).with("/index/auto/relationship/properties/foo")
+        expect(subject.connection).to receive(:delete).with("/index/auto/relationship/properties/foo")
         subject.remove_relationship_auto_index_property("foo")
       end
 

--- a/spec/unit/rest/relationship_indexes_spec.rb
+++ b/spec/unit/rest/relationship_indexes_spec.rb
@@ -7,7 +7,7 @@ module Neography
       subject { Neography::Rest.new }
 
       it "lists all indexes" do
-        subject.connection.should_receive(:get).with("/index/relationship")
+        expect(subject.connection).to receive(:get).with("/index/relationship")
         subject.list_relationship_indexes
       end
 
@@ -19,13 +19,13 @@ module Neography
           },
           "name" => "some_index"
         }
-        subject.connection.should_receive(:post).with("/index/relationship", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/index/relationship", json_match(:body, expected_body))
         subject.create_relationship_index("some_index", "some_type", "some_provider")
       end
 
       it "returns the post result after creation" do
-        subject.connection.stub(:post).and_return("foo")
-        subject.create_relationship_index("some_index", "some_type", "some_provider").should == "foo"
+        allow(subject.connection).to receive(:post).and_return("foo")
+        expect(subject.create_relationship_index("some_index", "some_type", "some_provider")).to eq("foo")
       end
 
       it "creates an auto-index" do
@@ -36,7 +36,7 @@ module Neography
           },
           "name" => "relationship_auto_index"
         }
-        subject.connection.should_receive(:post).with("/index/relationship", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/index/relationship", json_match(:body, expected_body))
         subject.create_relationship_auto_index("some_type", "some_provider")
       end
 
@@ -49,7 +49,7 @@ module Neography
           "end"        => "http://localhost:7474/node/43",
           "properties" => "properties"
         }
-        subject.connection.should_receive(:post).with("/index/relationship/some_index?unique", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/index/relationship/some_index?unique", json_match(:body, expected_body))
         subject.create_unique_relationship("some_index", "key", "value", "type", "42", "43", "properties")
       end
 
@@ -59,72 +59,72 @@ module Neography
           "key" => "key",
           "value" => "value"
         }
-        subject.connection.should_receive(:post).with("/index/relationship/some_index", json_match(:body, expected_body))
+        expect(subject.connection).to receive(:post).with("/index/relationship/some_index", json_match(:body, expected_body))
         subject.add_relationship_to_index("some_index", "key", "value", "42")
       end
 
       it "gets a relationship from an index" do
-        subject.connection.should_receive(:get).with("/index/relationship/some_index/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/relationship/some_index/some_key/some_value")
         subject.get_relationship_index("some_index", "some_key", "some_value")
       end
 
       it "returns nil if nothing was found in the index" do
-        subject.connection.stub(:get).and_return(nil)
-        subject.get_relationship_index("some_index", "some_key", "some_value").should be_nil
+        allow(subject.connection).to receive(:get).and_return(nil)
+        expect(subject.get_relationship_index("some_index", "some_key", "some_value")).to be_nil
       end
 
       it "finds by key and value if both passed to #find" do
-        subject.connection.should_receive(:get).with("/index/relationship/some_index/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/relationship/some_index/some_key/some_value")
         subject.find_relationship_index("some_index", "some_key", "some_value")
       end
 
       it "finds by query if no value passed to #find" do
-        subject.connection.should_receive(:get).with("/index/relationship/some_index?query=some_query")
+        expect(subject.connection).to receive(:get).with("/index/relationship/some_index?query=some_query")
         subject.find_relationship_index("some_index", "some_query")
       end
 
       it "finds by key query" do
-        subject.connection.should_receive(:get).with("/index/relationship/some_index/some_key/some_value")
+        expect(subject.connection).to receive(:get).with("/index/relationship/some_index/some_key/some_value")
         subject.find_relationship_index_by_key_value("some_index", "some_key", "some_value")
       end
 
       it "finds by query" do
-        subject.connection.should_receive(:get).with("/index/relationship/some_index?query=some_query")
+        expect(subject.connection).to receive(:get).with("/index/relationship/some_index?query=some_query")
         subject.find_relationship_index_by_query("some_index", "some_query")
       end
 
       it "removes a relationship from an index for #remove with two arguments" do
-        subject.connection.should_receive(:delete).with("/index/relationship/some_index/42")
+        expect(subject.connection).to receive(:delete).with("/index/relationship/some_index/42")
         subject.remove_relationship_from_index("some_index", "42")
       end
 
       it "removes a relationship from an index by key for #remove with three arguments" do
-        subject.connection.should_receive(:delete).with("/index/relationship/some_index/some_key/42")
+        expect(subject.connection).to receive(:delete).with("/index/relationship/some_index/some_key/42")
         subject.remove_relationship_from_index("some_index", "some_key", "42")
       end
 
       it "removes a relationship from an index by key and value for #remove with four arguments" do
-        subject.connection.should_receive(:delete).with("/index/relationship/some_index/some_key/some_value/42")
+        expect(subject.connection).to receive(:delete).with("/index/relationship/some_index/some_key/some_value/42")
         subject.remove_relationship_from_index("some_index", "some_key", "some_value", "42")
       end
 
       it "removes a relationship from an index" do
-        subject.connection.should_receive(:delete).with("/index/relationship/some_index/42")
+        expect(subject.connection).to receive(:delete).with("/index/relationship/some_index/42")
         subject.remove_relationship_index_by_id("some_index", "42")
       end
 
       it "removes a relationship from an index by key" do
-        subject.connection.should_receive(:delete).with("/index/relationship/some_index/some_key/42")
+        expect(subject.connection).to receive(:delete).with("/index/relationship/some_index/some_key/42")
         subject.remove_relationship_index_by_key("some_index", "42", "some_key")
       end
 
       it "removes a relationship from an index by key and value" do
-        subject.connection.should_receive(:delete).with("/index/relationship/some_index/some_key/some_value/42")
+        expect(subject.connection).to receive(:delete).with("/index/relationship/some_index/some_key/some_value/42")
         subject.remove_relationship_index_by_value("some_index", "42", "some_key", "some_value")
       end
 
       it "drops an index" do
-        subject.connection.should_receive(:delete).with("/index/relationship/some_index")
+        expect(subject.connection).to receive(:delete).with("/index/relationship/some_index")
         subject.drop_relationship_index("some_index")
       end
     end

--- a/spec/unit/rest/relationship_properties_spec.rb
+++ b/spec/unit/rest/relationship_properties_spec.rb
@@ -15,8 +15,8 @@ module Neography
           :body    => '"qux"',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:put).with("/relationship/42/properties/foo", options1)
-        subject.connection.should_receive(:put).with("/relationship/42/properties/baz", options2)
+        expect(subject.connection).to receive(:put).with("/relationship/42/properties/foo", options1)
+        expect(subject.connection).to receive(:put).with("/relationship/42/properties/baz", options2)
         subject.set_relationship_properties("42", {:foo => "bar", :baz => "qux"})
       end
 
@@ -25,36 +25,36 @@ module Neography
           :body    => '{"foo":"bar"}',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:put).with("/relationship/42/properties", options)
+        expect(subject.connection).to receive(:put).with("/relationship/42/properties", options)
         subject.reset_relationship_properties("42", {:foo => "bar"})
       end
 
       context "getting properties" do
 
         it "gets all properties" do
-          subject.connection.should_receive(:get).with("/relationship/42/properties")
+          expect(subject.connection).to receive(:get).with("/relationship/42/properties")
           subject.get_relationship_properties("42")
         end
 
         it "gets multiple properties" do
-          subject.connection.should_receive(:get).with("/relationship/42/properties/foo")
-          subject.connection.should_receive(:get).with("/relationship/42/properties/bar")
+          expect(subject.connection).to receive(:get).with("/relationship/42/properties/foo")
+          expect(subject.connection).to receive(:get).with("/relationship/42/properties/bar")
           subject.get_relationship_properties("42", "foo", "bar")
         end
 
         it "returns multiple properties as a hash" do
-          subject.connection.stub(:get).and_return("baz", "qux")
-          subject.get_relationship_properties("42", "foo", "bar").should == { "foo" => "baz", "bar" => "qux" }
+          allow(subject.connection).to receive(:get).and_return("baz", "qux")
+          expect(subject.get_relationship_properties("42", "foo", "bar")).to eq({ "foo" => "baz", "bar" => "qux" })
         end
 
         it "returns nil if no properties were found" do
-          subject.connection.stub(:get).and_return(nil, nil)
-          subject.get_relationship_properties("42", "foo", "bar").should be_nil
+          allow(subject.connection).to receive(:get).and_return(nil, nil)
+          expect(subject.get_relationship_properties("42", "foo", "bar")).to be_nil
         end
 
         it "returns hash without nil return values" do
-          subject.connection.stub(:get).and_return("baz", nil)
-          subject.get_relationship_properties("42", "foo", "bar").should == { "foo" => "baz" }
+          allow(subject.connection).to receive(:get).and_return("baz", nil)
+          expect(subject.get_relationship_properties("42", "foo", "bar")).to eq({ "foo" => "baz" })
         end
 
       end
@@ -62,13 +62,13 @@ module Neography
       context "removing properties" do
 
         it "removes all properties" do
-          subject.connection.should_receive(:delete).with("/relationship/42/properties")
+          expect(subject.connection).to receive(:delete).with("/relationship/42/properties")
           subject.remove_relationship_properties("42")
         end
 
         it "removes multiple properties" do
-          subject.connection.should_receive(:delete).with("/relationship/42/properties/foo")
-          subject.connection.should_receive(:delete).with("/relationship/42/properties/bar")
+          expect(subject.connection).to receive(:delete).with("/relationship/42/properties/foo")
+          expect(subject.connection).to receive(:delete).with("/relationship/42/properties/bar")
           subject.remove_relationship_properties("42", "foo", "bar")
         end
 

--- a/spec/unit/rest/relationship_types_spec.rb
+++ b/spec/unit/rest/relationship_types_spec.rb
@@ -7,7 +7,7 @@ module Neography
       subject { Neography::Rest.new }
 
       it "lists all relationship types" do
-        subject.connection.should_receive(:get).with("/relationship/types")
+        expect(subject.connection).to receive(:get).with("/relationship/types")
         subject.list_relationship_types
       end
     end

--- a/spec/unit/rest/relationships_spec.rb
+++ b/spec/unit/rest/relationships_spec.rb
@@ -7,12 +7,12 @@ module Neography
       subject { Neography::Rest.new }
 
       it "gets a relationship" do
-        subject.connection.should_receive(:get).with("/relationship/42")
+        expect(subject.connection).to receive(:get).with("/relationship/42")
         subject.get_relationship("42")
       end
 
       it "deletes a relationship" do
-        subject.connection.should_receive(:delete).with("/relationship/42")
+        expect(subject.connection).to receive(:delete).with("/relationship/42")
         subject.delete_relationship("42")
       end
 

--- a/spec/unit/rest/schema_index_spec.rb
+++ b/spec/unit/rest/schema_index_spec.rb
@@ -11,17 +11,17 @@ module Neography
           :body    => '{"property_keys":["name"]}',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:post).with("/schema/index/person", options)
+        expect(subject.connection).to receive(:post).with("/schema/index/person", options)
         subject.create_schema_index("person", ["name"])
       end
 
       it "get schema indexes" do
-        subject.connection.should_receive(:get).with("/schema/index/person")
+        expect(subject.connection).to receive(:get).with("/schema/index/person")
         subject.get_schema_index("person")
       end
       
       it "delete schema indexes" do
-        subject.connection.should_receive(:delete).with("/schema/index/person/name")
+        expect(subject.connection).to receive(:delete).with("/schema/index/person/name")
         subject.delete_schema_index("person","name")
       end
       

--- a/spec/unit/rest/transactions_spec.rb
+++ b/spec/unit/rest/transactions_spec.rb
@@ -11,7 +11,7 @@ module Neography
           :body    => '{"statements":[]}',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:post).with("/transaction", options)
+        expect(subject.connection).to receive(:post).with("/transaction", options)
         subject.begin_transaction
       end
 
@@ -20,7 +20,7 @@ module Neography
           :body    => '{"statements":[]}',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:post).with("/transaction/1", options)
+        expect(subject.connection).to receive(:post).with("/transaction/1", options)
         subject.in_transaction(1, [])
       end
 
@@ -29,12 +29,12 @@ module Neography
           :body    => '{"statements":[]}',
           :headers => json_content_type
         }
-        subject.connection.should_receive(:post).with("/transaction/1/commit", options)
+        expect(subject.connection).to receive(:post).with("/transaction/1/commit", options)
         subject.commit_transaction(1, [])
       end
 
       it "can rollback transactions" do
-        subject.connection.should_receive(:delete).with("/transaction/1")
+        expect(subject.connection).to receive(:delete).with("/transaction/1")
         subject.rollback_transaction(1)
       end
       


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 935 conversions
  from: obj.should
    to: expect(obj).to
- 597 conversions
  from: == expected
    to: eq(expected)
- 188 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 159 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 48 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 19 conversions
  from: its(:attr) { }
    to: describe '#attr' do subject { super().attr }; it { } end
- 6 conversions
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)
- 2 conversions
  from: =~ [1, 2]
    to: match_array([1, 2])
- 1 conversion
  from: > expected
    to: be > expected
