### PR TITLE
Label handling for Neography::Node objects

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,14 +1,6 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
 guard :rspec do
-  # Just rerun the whole suite until the file names are matching
-  # in lib/ and spec/
-  #
-  # watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
-  # watch(%r{^lib/(.+)\.rb$})     { |m| "spec/unit/lib/#{m[1]}_spec.rb" }
-  watch(%r{^lib/(.+)\.rb$})     { "spec" }
-
+  watch(%r{^lib/neography/(.+)\.rb$}) { |m| "spec/unit/#{m[1]}_spec.rb" }
+  watch(%r{^lib/neography/(.+)\.rb$}) { |m| "spec/integration/#{m[1]}_spec.rb" }
   watch(%r{^spec/.+_spec\.rb$})
   watch('spec/spec_helper.rb')  { "spec" }
 end

--- a/lib/neography/node.rb
+++ b/lib/neography/node.rb
@@ -53,11 +53,34 @@ module Neography
       end
     end
 
-    ##
-    # List of labels of current node.
-    # Returns array of strings
     def labels
-      self.neo_server.get_node_labels(self.neo_id)
+      @cached_labels ||= [self.neo_server.get_node_labels(self.neo_id)].compact.flatten
+    end
+
+    def set_labels(labels)
+      # I just invalidate the cache instead of updating it to make sure
+      # it doesn't contain something else than what ends up in neo4j
+      # (consider duplicate/invalid labels, etc).
+      @cached_labels = nil
+      self.neo_server.set_label(self, [labels].flatten)
+    end
+    alias_method :set_label, :set_labels
+
+    def add_labels(labels)
+      # Just invalidating the cache on purpose, see set_labels
+      @cached_labels = nil
+      self.neo_server.add_label(self, [labels].flatten)
+    end
+    alias_method :add_label, :add_labels
+
+
+    def delete_label(label)
+      @cached_labels = nil
+      self.neo_server.delete_label(self, label)
+    end
+
+    def cached_labels=(labels)
+      @cached_labels = [labels].flatten
     end
   end
 end

--- a/neography.gemspec
+++ b/neography.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "rspec", ">= 2.11"
+  s.add_development_dependency "rspec", "3.0"
   s.add_development_dependency "net-http-spy", "0.2.1"
   s.add_development_dependency "coveralls"
   s.add_development_dependency "debugger"

--- a/spec/integration/node_spec.rb
+++ b/spec/integration/node_spec.rb
@@ -247,14 +247,41 @@ describe Neography::Node do
     end
   end
 
-  describe 'gets labels' do
-    let(:subject) {
+  describe 'labels' do
+
+    it "loading from neo4j" do
       node = Neography::Node.create
       node.neo_server.add_label(node, 'Label')
       node.neo_server.add_label(node, 'Label2')
-      node
-    }
+      expect(node.labels).to eq(%w(Label Label2))
+    end
 
-    it { expect(subject.labels).to eq(%w(Label Label2)) }
+    it "adding via the node" do
+      node = Neography::Node.create
+      node.neo_server.add_label(node, 'Label')
+      node.add_labels('Label2')
+      expect(node.labels).to eq(%w(Label Label2))
+    end
+
+    it "resetting via the node" do
+      node = Neography::Node.create
+      node.neo_server.add_label(node, 'Label')
+      expect do
+        node.set_labels("Reset")
+      end.to change{ node.labels }.from(['Label']).to(["Reset"])
+    end
+
+    it "deleting via the node" do
+      node = Neography::Node.create
+      node.neo_server.add_label(node, 'Label')
+      expect do
+        node.delete_label("Label")
+      end.to change{ node.labels }.from(['Label']).to([])
+    end
+
+
+
+
   end
+
 end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -27,6 +27,76 @@ module Neography
           Node.create(properties)
         end
 
+        describe "labels" do
+          let(:node){ Node.create }
+
+          it "are only fetched once" do
+            expect(@db).to receive(:get_node_labels).exactly(1).and_return []
+            node.labels
+            node.labels
+          end
+
+          it "cache can be set from the outside" do
+            expect(@db).to_not receive(:get_node_labels)
+            node.cached_labels = ["Bar"]
+
+            expect(node.labels).to eq ["Bar"]
+          end
+
+          it "cache is invalidated when labels are set" do
+            expect(@db).to receive(:get_node_labels).exactly(2).and_return []
+            expect(@db).to receive(:set_label).exactly(1)
+            node.labels
+            node.set_labels("Something")
+            node.labels
+          end
+
+          it "cache is invalidated when labels are set" do
+            expect(@db).to receive(:get_node_labels).exactly(2).and_return []
+            expect(@db).to receive(:add_label).exactly(1)
+            node.labels
+            node.add_labels("Something")
+            node.labels
+          end
+
+          it "cache is invalidated when labels are deleted" do
+            expect(@db).to receive(:get_node_labels).exactly(2).and_return []
+            expect(@db).to receive(:delete_label).exactly(1)
+            node.labels
+            node.delete_label("Something")
+            node.labels
+          end
+
+          describe "set" do
+            it "as a single label" do
+              expect(@db).to receive(:set_label).with(node, ["Foo"])
+              node.set_label("Foo")
+            end
+
+            it "as an array" do
+              expect(@db).to receive(:set_label).with(node, ["Foo"])
+              node.set_labels(["Foo"])
+            end
+          end
+
+          describe "add" do
+            it "as a single label" do
+              expect(@db).to receive(:add_label).with(node, ["Foo"])
+              node.add_label("Foo")
+            end
+
+            it "as an array" do
+              expect(@db).to receive(:add_label).with(node, ["Foo"])
+              node.add_labels(["Foo"])
+            end
+          end
+
+          it "can be deleted" do
+            expect(@db).to receive(:delete_label).with(node, "Foo")
+            node.delete_label("Foo")
+          end
+        end
+
       end
 
       context "explicit server" do
@@ -79,18 +149,18 @@ module Neography
 
       context "explicit server" do
 
-        it "cannot pass a server as the first argument, node as the second (depracted)" do
+        it "cannot pass a server as the first argument, node as the second (deprecated)" do
           @other_server = Neography::Rest.new
           expect(@other_server).not_to receive(:get_node).with(42)
           expect {
-            node = Node.load(@other_server, 42)
+            Node.load(@other_server, 42)
           }.to raise_error(ArgumentError)
         end
 
         it "can pass a node as the first argument, server as the second" do
           @other_server = Neography::Rest.new
           expect(@other_server).to receive(:get_node).with(42)
-          node = Node.load(42, @other_server)
+          Node.load(42, @other_server)
         end
 
       end


### PR DESCRIPTION
Adds `set_labels`, `add_labels` and `delete_label` methods for nodes and
caches the values fetched from neo4j so that multiple calls of `labels`
only issue one request. As with node props, the cached labels can be set from the outside.

Also updated the `Guardfile` so that unit/integration are run on a per file level from `lib/neography`.

Rspec depdency updated to `>=3.0` because the suite didn't run locally with rspec 2.x.
