### PR TITLE
Remove method that overrides Object#equal? (cleanup)

### DIFF
--- a/lib/neography/equal.rb
+++ b/lib/neography/equal.rb
@@ -3,10 +3,6 @@ module Neography
   # == This mixin is used for both nodes and relationships to decide if two entities are equal or not.
   #
   module Equal
-    def equal?(o)
-      eql?(o)
-    end
-
     def eql?(o)
       return false unless o.respond_to?(:neo_id)
       o.neo_id == neo_id

--- a/spec/integration/node_spec.rb
+++ b/spec/integration/node_spec.rb
@@ -121,12 +121,6 @@ describe Neography::Node do
   end
 
   describe "equality" do
-    it "can tell two nodes are the same with equal?" do
-      new_node = Neography::Node.create
-      another_node = Neography::Node.load(new_node)
-      expect(new_node.equal?(another_node)).to be true 
-    end
-
     it "can tell two nodes are the same with eql?" do
       new_node = Neography::Node.create
       another_node = Neography::Node.load(new_node)


### PR DESCRIPTION
From the docs:

> Unlike ==, the equal? method should never be overridden by subclasses
> as it is used to determine object identity (that is, a.equal?(b) if
> and only if a is the same object as b)

sources:
http://www.ruby-doc.org/core-1.9.3/BasicObject.html#method-i-equal-3F
http://www.ruby-doc.org/core-2.1.2/BasicObject.html#method-i-equal-3F
