### PR TITLE
added :persistent as a configurable option

### DIFF
--- a/lib/neography/config.rb
+++ b/lib/neography/config.rb
@@ -7,7 +7,8 @@ module Neography
       :max_threads,
       :authentication, :username, :password,
       :parser, :max_execution_time,
-      :proxy, :http_send_timeout, :http_receive_timeout
+      :proxy, :http_send_timeout, :http_receive_timeout,
+      :persistent
 
     def initialize
       set_defaults
@@ -33,7 +34,8 @@ module Neography
         :max_execution_time    => @max_execution_time,
         :proxy                 => @proxy,
         :http_send_timeout     => @http_send_timeout,
-        :http_receive_timeout  => @http_receive_timeout
+        :http_receive_timeout  => @http_receive_timeout,
+        :persistent            => @persistent
       }
     end
 
@@ -58,7 +60,7 @@ module Neography
       @proxy                = nil
       @http_send_timeout    = 1200
       @http_receive_timeout = 1200
-      end
-
+      @persistent           = true
+    end
   end
 end

--- a/lib/neography/connection.rb
+++ b/lib/neography/connection.rb
@@ -19,7 +19,7 @@ module Neography
       @client ||= Excon.new(config[:proxy] || "#{@protocol}#{@server}:#{@port}", 
                             :read_timeout => config[:http_receive_timeout],
                             :write_timeout => config[:http_send_timeout],
-                            :persistent => true,
+                            :persistent => config[:persistent],
                             :user =>  config[:username],
                             :password => config[:password])
       #authenticate

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -102,6 +102,11 @@ module Neography
         it  { should == 1200 }
       end
 
+      describe '#persistent' do
+        subject { super().persistent }
+        it { should == true }
+      end
+
 
       it "has a hash representation" do
         expected_hash = {
@@ -123,7 +128,8 @@ module Neography
           :max_execution_time   => 6000,
           :proxy                => nil,
           :http_send_timeout    => 1200,
-          :http_receive_timeout => 1200
+          :http_receive_timeout => 1200,
+          :persistent           => true
 
         }
         expect(config.to_hash).to eq(expected_hash)

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -79,6 +79,25 @@ module Neography
             connection
           end
         end
+
+        context "persistent" do
+          let(:persistent) { double(:persistent)}
+          let(:options) do
+            {
+              :persistent => false
+            }
+          end
+
+          it 'configures persistent' do
+            expect(Excon).to receive(:new).with("http://localhost:7474",
+                                                :read_timeout => 1200,
+                                                :write_timeout => 1200,
+                                                :persistent => false,
+                                                :user => nil,
+                                                :password => nil).and_return(persistent)
+            connection
+          end
+        end
       end
 
 


### PR DESCRIPTION
Excon allows for non-persistent and persistent connections.  This PR allows "persistent" in neography to be configurable to true/false as opposed to the default value of true so that clients can choose to use either persistent or non-persistent connections.
