### PR TITLE
Fixes issue with NEO4J_URL environment variable

### DIFF
--- a/lib/neography/connection.rb
+++ b/lib/neography/connection.rb
@@ -13,7 +13,7 @@ module Neography
       :parser, :client,
       :proxy, :http_send_timeout, :http_receive_timeout
 
-    def initialize(options = ENV['NEO4J_URL'] || {})
+    def initialize(options = {})
       config = merge_configuration(options)
       save_local_configuration(config)
       @client ||= Excon.new(config[:proxy] || "#{@protocol}#{@server}:#{@port}", 

--- a/lib/neography/rest.rb
+++ b/lib/neography/rest.rb
@@ -60,7 +60,7 @@ module Neography
 
     def_delegators :@connection, :configuration
 
-    def initialize(options = ENV['NEO4J_URL'] || {})
+    def initialize(options = {})
       @connection = Connection.new(options)
     end   
 


### PR DESCRIPTION
Found an issue when the NEO4J_URL environment variable was set.

We used that variable for configuration and it caused some strange things to happen because the variable held a string, not an hash. 

My guess is that the interface has changed, maybe that the initializer took a string at one time but it has changed to hash? 
